### PR TITLE
Bug fix 31

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -70,7 +70,7 @@ Variable var_info[] = {
 	// Vars in et_struct
 	//--------------------
 	{ 32, "potential_et_m_per_s",        "double", 1 },
-	{ 33, "potential_et_m_per_timestep", "double", 1 },
+	{ 33, "potential_et_m_per_timestep", "double", 1 }, //TODO Doesn't appear to be used, but this is uninitialized
 	{ 34, "actual_et_m_per_timestep",    "double", 1 },
 	//------------------------------
 	// Vars in vol_tracking_struct
@@ -837,12 +837,17 @@ static int Initialize (Bmi *self, const char *file)
         changing the name to the more general "direct runoff"
     cfe_bmi_data_ptr->flux_Schaake_output_runoff_m = malloc(sizeof(double));*/
     cfe_bmi_data_ptr->flux_output_direct_runoff_m  = malloc(sizeof(double));
-
+    *cfe_bmi_data_ptr->flux_output_direct_runoff_m = 0.0;
     cfe_bmi_data_ptr->flux_Qout_m = malloc(sizeof(double));
+    *cfe_bmi_data_ptr->flux_Qout_m = 0.0;
     cfe_bmi_data_ptr->flux_from_deep_gw_to_chan_m = malloc(sizeof(double));
+    *cfe_bmi_data_ptr->flux_from_deep_gw_to_chan_m = 0.0;
     cfe_bmi_data_ptr->flux_giuh_runoff_m = malloc(sizeof(double));
+    *cfe_bmi_data_ptr->flux_giuh_runoff_m = 0.0;
     cfe_bmi_data_ptr->flux_lat_m = malloc(sizeof(double));
+    *cfe_bmi_data_ptr->flux_lat_m = 0.0;
     cfe_bmi_data_ptr->flux_nash_lateral_runoff_m = malloc(sizeof(double));
+    *cfe_bmi_data_ptr->flux_nash_lateral_runoff_m = 0.0;
     cfe_bmi_data_ptr->flux_perc_m = malloc(sizeof(double));
     //This needs an initial value, it is used in computations in CFE and only set towards the end of the model
     //See issue #31
@@ -857,7 +862,9 @@ static int Initialize (Bmi *self, const char *file)
     if (strcmp(cfe_bmi_data_ptr->forcing_file, "BMI") == 0){
         cfe_bmi_data_ptr->is_forcing_from_bmi = TRUE;
         cfe_bmi_data_ptr->forcing_data_precip_kg_per_m2 = malloc(sizeof(double));
+        *cfe_bmi_data_ptr->forcing_data_precip_kg_per_m2 = 0.0;
         cfe_bmi_data_ptr->forcing_data_time = malloc(sizeof(long));
+        *cfe_bmi_data_ptr->forcing_data_time = 0;
     }
     else
     {

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -844,6 +844,9 @@ static int Initialize (Bmi *self, const char *file)
     cfe_bmi_data_ptr->flux_lat_m = malloc(sizeof(double));
     cfe_bmi_data_ptr->flux_nash_lateral_runoff_m = malloc(sizeof(double));
     cfe_bmi_data_ptr->flux_perc_m = malloc(sizeof(double));
+    //This needs an initial value, it is used in computations in CFE and only set towards the end of the model
+    //See issue #31
+    *cfe_bmi_data_ptr->flux_perc_m = 0.0;
 
     /*******************************************************
        JMFRAME: Check to see where forcings come from

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2418,6 +2418,7 @@ extern double init_reservoir_storage(int is_ratio, double amount, double max_amo
 }
 
 extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr){
+    cfe_ptr->vol_struct.volin = 0;
     cfe_ptr->vol_struct.vol_runoff = 0;
     cfe_ptr->vol_struct.vol_infilt = 0;
     cfe_ptr->vol_struct.vol_to_soil = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -102,10 +102,10 @@ int
       print_cfe_flux_header();
 
   // Run the model with the update until function
-  cfe_bmi_model2->update_until(cfe_bmi_model2, 45 * model_time_step_size);
+  cfe_bmi_model2->update_until(cfe_bmi_model2, 45*model_time_step_size);
 
-  if (cfe_main_data->verbosity > 0)
-      print_cfe_flux_at_timestep(cfe_main_data);
+  if (cfe_main_data2->verbosity > 0)
+      print_cfe_flux_at_timestep(cfe_main_data2);
 
   // Run the Mass Balance check
   //mass_balance_check(cfe_main_data);


### PR DESCRIPTION
Need to ensure any variables used in computation have some initial value before they are used in any operation.

## Changes

* Initial values for variables that were using bad memory
    - `flux_perc_m`
    - `volin`
* For good practice, initialize a few other variables to 0.0
* Fix bug in main driver as well

## Testing

1. Ran several iterations with consistent, non earth ending output values.

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOs
