### PR TITLE
Track fractional time and adjust input accordingly

### DIFF
--- a/include/bmi_cfe.h
+++ b/include/bmi_cfe.h
@@ -71,7 +71,7 @@ struct cfe_state_struct {
     int num_timesteps;
     int current_time_step;
     int time_step_size;
-  
+    double time_step_fraction;
     // an integer to flag the forcings coming as "set_value" from BMI
     int is_forcing_from_bmi;
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -974,6 +974,9 @@ static int Update (Bmi *self)
       // divide by 1000 to convert from mm/h to m w/ 1h timestep as per t-shirt_0.99f
       cfe_ptr->timestep_rainfall_input_m = cfe_ptr->forcing_data_precip_kg_per_m2[cfe_ptr->current_time_step] /1000;
     
+    //Adjust the rainfall input by a potential fraction of the time step
+    cfe_ptr->timestep_rainfall_input_m *= cfe_ptr->time_step_fraction;
+    //Accumulate volume for mass balance
     cfe_ptr->vol_struct.volin += cfe_ptr->timestep_rainfall_input_m;
     
     run_cfe(cfe_ptr);
@@ -1015,8 +1018,11 @@ static int Update_until (Bmi *self, double t)
         
         // change timestep to remaining fraction & call update()
         cfe_ptr->time_step_size = frac * dt;
+        //Record the time step fraction so `Update` can adjust input if needed
+        cfe_ptr->time_step_fraction = frac;
         Update (self);
         // set back to original
+        cfe_ptr->time_step_fraction = 1.0;
         cfe_ptr->time_step_size = dt;
     }
     
@@ -2218,7 +2224,7 @@ cfe_state_struct *new_bmi_cfe(void)
     cfe_state_struct *data;
     data = (cfe_state_struct *) malloc(sizeof(cfe_state_struct));
     data->time_step_size = 3600;
-    
+    data->time_step_fraction = 1.0;
     data->forcing_data_precip_kg_per_m2 = NULL;
     data->forcing_data_time = NULL;
     data->giuh_ordinates = NULL;


### PR DESCRIPTION
In the case that Update_until is used and a fractional timestep is run, need to attempt to scale the input to match the time framction.

## Additions

- Add `time_step_fraction` in cfe_state_struct

## Changes

- Use `time_step_fraction` in `Update` to scale input prior to running CFE

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Linux
- [x] MacOS
