### PR TITLE
Valid use of `evap_struct` (for all members)

### DIFF
--- a/include/cfe.h
+++ b/include/cfe.h
@@ -206,7 +206,8 @@ extern void cfe(
         double *nash_storage_arr,
         struct evapotranspiration_structure *evap_struct,
         double *Qout_m_ptr,
-        struct massbal *massbal_struct
+        struct massbal *massbal_struct,
+        double time_step_size
     );
 
 #endif //CFE_CFE_H

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -950,6 +950,7 @@ static int Initialize (Bmi *self, const char *file)
     //          Will subtract this from the soil moisture and infiltration mass.
     cfe_bmi_data_ptr->et_struct.potential_et_m_per_s = 0;
     cfe_bmi_data_ptr->et_struct.actual_et_m_per_timestep = 0;
+    cfe_bmi_data_ptr->et_struct.potential_et_m_per_timestep = 0;
 
     // Set all the mass balance trackers to zero.
     initialize_volume_trackers(cfe_bmi_data_ptr);
@@ -2350,7 +2351,8 @@ extern void run_cfe(cfe_state_struct* cfe_ptr){
         cfe_ptr->nash_storage,                              // Set from config file
         &cfe_ptr->et_struct,                                    // Set to zero with initalize. Set by BMI (set_value) during run
         cfe_ptr->flux_Qout_m,                                    // Set by CFE function
-        &cfe_ptr->vol_struct
+        &cfe_ptr->vol_struct,
+        cfe_ptr->time_step_size
     );
 }
 

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -39,7 +39,8 @@ extern void cfe(
         double *nash_storage_arr,
         struct evapotranspiration_structure *evap_struct,
         double *Qout_m_ptr,
-        struct massbal *massbal_struct
+        struct massbal *massbal_struct,
+        double time_step_size
     ){                      // #######################################################################
 // CFE STATE SPACE FUNCTION // #######################################################################
 
@@ -75,6 +76,8 @@ extern void cfe(
 
   soil_reservoir_storage_deficit_m=(NWM_soil_params_struct.smcmax*NWM_soil_params_struct.D-soil_reservoir_struct->storage_m);
 
+  evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
+
   et_from_rainfall(&timestep_rainfall_input_m,evap_struct);
  
   // NEW FLO
@@ -105,6 +108,7 @@ extern void cfe(
     infiltration_depth_m = 0.0;
     }
   et_from_soil(soil_reservoir_struct, evap_struct, &NWM_soil_params_struct);
+
   // check to make sure that there is storage available in soil to hold the water that does not runoff
   //--------------------------------------------------------------------------------------------------
   if(soil_reservoir_storage_deficit_m<infiltration_depth_m)


### PR DESCRIPTION
`evap_struct` [type-def'ed ](https://github.com/NOAA-OWP/cfe/blob/023b794f599e48984e5f2f99f70cdfcc82e3f29b/include/cfe.h#L207 ) as 
```
struct evapotranspiration_structure {
    double potential_et_m_per_s;
    double potential_et_m_per_timestep;
    double actual_et_m_per_timestep;
};
``` 
is fully [initialized](https://github.com/NOAA-OWP/cfe/blob/92f253654494d810115d1d37d97607128a159903/src/bmi_cfe.c#L953) and [set/updated](https://github.com/NOAA-OWP/cfe/blob/92f253654494d810115d1d37d97607128a159903/src/cfe.c#L79) (assigned value) for all members, including now `potential_et_m_per_timestep`.  

This is needed for subroutine functions [`et_from_rainfall`](https://github.com/NOAA-OWP/cfe/blob/023b794f599e48984e5f2f99f70cdfcc82e3f29b/src/cfe.c#L666) & [`et_from_soil`](https://github.com/NOAA-OWP/cfe/blob/023b794f599e48984e5f2f99f70cdfcc82e3f29b/src/cfe.c#L693) called [here](https://github.com/NOAA-OWP/cfe/blob/023b794f599e48984e5f2f99f70cdfcc82e3f29b/src/cfe.c#L78) and [here](https://github.com/NOAA-OWP/cfe/blob/master/src/cfe.c#L107) respectively. 

Note that model struct `cfe` now requires [`time_step_size`](https://github.com/NOAA-OWP/cfe/blob/evap-struct-fix/src/cfe.c#L43) for `potential_et_m_per_s` to `potential_et_m_per_timestep` conversion.  (Unless there is a more appropriate place in `bmi.initialize()`?

Fixes Issue #35
