### PR TITLE
allow bmi to set calibration parameters

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -15,6 +15,16 @@
 #define OUTPUT_VAR_NAME_COUNT 6
 #define STATE_VAR_NAME_COUNT 89   // must match var_info array size
 
+#define PARAM_VAR_NAME_COUNT 10
+static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
+    "maxsmc", "satdk", "slope", "b", "multiplier", "Klf", 
+    "Kn", "Cgw", "expon", "max_gw_storage"
+};
+
+static const char *param_var_types[PARAM_VAR_NAME_COUNT] = {
+    "double", "double", "double", "double", "double", "double",
+    "double", "double", "double", "double"
+};
 //----------------------------------------------
 // Put variable info into a struct to simplify
 // BMI implementation and avoid errors.

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -815,6 +815,13 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model, doubl
 
 static int Initialize (Bmi *self, const char *file)
 {
+    //FIXME, we can use the input file to help imply "framework" support or "standalone"
+    //an empty init file string indicates things will come from set_value???
+    //what happens when both occur, that is we have a config file and framewrok
+    //using set_value after init???
+
+    //Consider enumeration of failure states and how that might look across multiple languages
+    //integrating into a framework
 
     cfe_state_struct* cfe_bmi_data_ptr;
 
@@ -1163,6 +1170,8 @@ static int Get_var_grid(Bmi *self, const char *name, int *grid)
 
 static int Get_var_type (Bmi *self, const char *name, char * type)
 {
+    //TODO may need to expose type info for "hidden" parameter values
+    //or impose BMI side casting of double to whatever type
     // Check to see if in output array first
     for (i = 0; i < OUTPUT_VAR_NAME_COUNT; i++) {
         if (strcmp(name, output_var_names[i]) == 0) {
@@ -1193,6 +1202,8 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
 
 static int Get_var_itemsize (Bmi *self, const char *name, int * size)
 {
+    //TODO may need to implement for "hidden" parameter variables
+    //or impose BMI side casting from double to desired type
     char type[BMI_MAX_TYPE_NAME];
     int type_result = Get_var_type(self, name, type);
     if (type_result != BMI_SUCCESS) {
@@ -1501,6 +1512,24 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     if (status == BMI_FAILURE)
         return BMI_FAILURE;
     memcpy(ptr, src, var_item_size * len);
+    /*
+    * If we want to modify the number of nash cascades, we must also side effect other
+    * variables.  This "should" work, based on current program structure
+    */
+    /*
+    if (strcmp (name, "number_nash_reservoirs") ) {
+    
+            //Note that this only allows adjustment to the number of cascades,
+            //and each one will have initial storage value of 0.0
+            //Reallocate nash_storage
+            if( model->nash_storage != NULL ) free(model->nash_storage);
+            model->nash_storage = malloc(sizeof(double) * model->num_lateral_flow_nash_reservoirs);
+            if( model->nash_storage == NULL ) return BMI_FAILURE;
+            for (j = 0; j < model->num_lateral_flow_nash_reservoirs; j++)
+                model->nash_storage[j] = 0.0;
+        
+    }
+    */
     return BMI_SUCCESS;
 }
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1177,6 +1177,14 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
             return BMI_SUCCESS;
         }
     }
+
+    for (i = 0; i < PARAM_VAR_NAME_COUNT; i++) {
+        if (strcmp(name, param_var_names[i]) == 0) {
+            strncpy(type, param_var_types[i], BMI_MAX_TYPE_NAME);
+            return BMI_SUCCESS;
+        }
+    }
+
     // If we get here, it means the variable name wasn't recognized
     type[0] = '\0';
     return BMI_FAILURE;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1303,6 +1303,72 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
 
 static int Get_value_ptr (Bmi *self, const char *name, void **dest)
 {
+    /*********** Calibration Params Hacked ************/
+    if (strcmp (name, "maxsmc") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->NWM_soil_params.smcmax;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "satdk") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->NWM_soil_params.satdk;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "slope") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->NWM_soil_params.slop;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "b") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->NWM_soil_params.bb;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "multiplier") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->NWM_soil_params.mult;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "Klf") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->soil_reservoir.coeff_secondary;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "Kn") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->K_nash;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "Cgw") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->gw_reservoir.coeff_primary;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "expon") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->gw_reservoir.exponent_primary;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, "max_gw_storage") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->gw_reservoir.storage_max_m;
+        return BMI_SUCCESS;
+    }
+    
+    
+    //NOT MESSING WITH nash_n (number of nash cascades) cause it is a bit of a side
+    //effecting value when it changes
+
     /***********************************************************/
     /***********    OUTPUT   ***********************************/
     /***********************************************************/

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1129,6 +1129,11 @@ static int Get_adjusted_index_for_variable(const char *name)
             return i + OUTPUT_VAR_NAME_COUNT;
     }
 
+    for (i = 0; i < PARAM_VAR_NAME_COUNT; i++){
+    if (strcmp(name, param_var_names[i]) == 0)
+        return i + INPUT_VAR_NAME_COUNT + OUTPUT_VAR_NAME_COUNT;
+    }
+
     return -1;
 }
 


### PR DESCRIPTION
Tweaks to CFE BMI to allow setting calibration parameters after model initialization, using existing BMI functionality

## Additions

-  `param_var_names`, `param_var_types`

## Removals

-

## Changes

- Add params to `Get_adjusted_index_for_variable`, `Get_var_type`, `Get_value_ptr`

## Testing

1. Tested via ngen build which sets param values after initialization (and via calibration loop execution)

## Todos

- A few comments/notes left in the code disscussion side effecting parameters and considerations for a couple other bmi functions.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support
- [x] Linux
- [x] MacOs
