### PR TITLE
fix negative pet, error in water balance remains

### DIFF
--- a/forcing_code/src/pet.c
+++ b/forcing_code/src/pet.c
@@ -128,7 +128,9 @@ extern int run_pet(pet_model* model)
     model->pet_m_per_s=pevapotranspiration_priestley_taylor_method(model);
   if(model->pet_options.use_penman_monteith_method ==1)
     model->pet_m_per_s=pevapotranspiration_penman_monteith_method(model);
-
+  if(model->pet_m_per_s<0) {
+    model->pet_m_per_s = 0;
+  }
   if (model->bmi.verbose >=1){
     printf("\n");
     printf("_______________________________________________________________________________\n");


### PR DESCRIPTION
Fix possibility of negative PET due to negative net radiation over night. 

## Additions
Condition to turn PET into zero if negative 

## Changes

-

## Testing

Tested with current make_and_run_bmi_pass_forcings_pet.sh

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [ x] Changes are limited to a single goal (no scope creep)
- [ x] Code can be automatically merged (no conflicts)
- [ x] Code follows project standards (link if applicable)
- [ x] Passes all existing automated tests
- [ x] Any _change_ in functionality is tested
- [ x] New functions are documented (with a description, list of inputs, and expected output)
- [ x] Placeholder code is flagged / future todos are captured in comments
- [ x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
