### PR TITLE
Adding ET to output

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -12,7 +12,7 @@
 #define CFE_DEGUG 0
 
 #define INPUT_VAR_NAME_COUNT 2
-#define OUTPUT_VAR_NAME_COUNT 6
+#define OUTPUT_VAR_NAME_COUNT 8
 #define STATE_VAR_NAME_COUNT 89   // must match var_info array size
 
 #define PARAM_VAR_NAME_COUNT 10
@@ -168,10 +168,14 @@ static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "GIUH_RUNOFF",
         "NASH_LATERAL_RUNOFF",
         "DEEP_GW_TO_CHANNEL_FLUX",
-        "Q_OUT"
+        "Q_OUT",
+        "POTENTIAL_ET",
+        "ACTUAL_ET"
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
+        "double",
+        "double",
         "double",
         "double",
         "double",
@@ -186,10 +190,14 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+        1,
+        1,
         1
 };
 
 static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
+        "m",
+        "m",
         "m",
         "m",
         "m",
@@ -204,10 +212,14 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+        0,
+        0,
         0
 };
 
 static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
+        "node",
+        "node",
         "node",
         "node",
         "node",
@@ -1412,6 +1424,19 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
+    if (strcmp (name, "POTENTIAL_ET") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr-> et_struct.potential_et_m_per_timestep;
+        return BMI_SUCCESS;
+    }
+
+    if (strcmp (name, "ACTUAL_ET") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr-> et_struct.actual_et_m_per_timestep;
+        return BMI_SUCCESS;
+    }    
     /***********************************************************/
     /***********    INPUT    ***********************************/
     /***********************************************************/

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -12,7 +12,7 @@
 #define CFE_DEGUG 0
 
 #define INPUT_VAR_NAME_COUNT 2
-#define OUTPUT_VAR_NAME_COUNT 8
+#define OUTPUT_VAR_NAME_COUNT 10
 #define STATE_VAR_NAME_COUNT 89   // must match var_info array size
 
 #define PARAM_VAR_NAME_COUNT 10
@@ -162,18 +162,20 @@ int j = 0;
 // Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
 static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "RAIN_RATE",
-        /* xinanjiang_dev
-        "SCHAAKE_OUTPUT_RUNOFF",*/
         "DIRECT_RUNOFF",
         "GIUH_RUNOFF",
         "NASH_LATERAL_RUNOFF",
         "DEEP_GW_TO_CHANNEL_FLUX",
         "Q_OUT",
         "POTENTIAL_ET",
-        "ACTUAL_ET"
+        "ACTUAL_ET",
+        "GW_STORAGE",
+        "SOIL_STORAGE"
 };
 
 static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
+        "double",
+        "double",
         "double",
         "double",
         "double",
@@ -192,10 +194,14 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+        1,
+        1,
         1
 };
 
 static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
+        "m",
+        "m",
         "m",
         "m",
         "m",
@@ -214,10 +220,14 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+        0,
+        0,
         0
 };
 
 static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
+        "node",
+        "node",
         "node",
         "node",
         "node",
@@ -1436,7 +1446,21 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         cfe_ptr = (cfe_state_struct *) self->data;
         *dest = (void*)&cfe_ptr-> et_struct.actual_et_m_per_timestep;
         return BMI_SUCCESS;
-    }    
+    }
+    
+    if (strcmp (name, "GW_STORAGE") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr-> gw_reservoir.storage_m;
+        return BMI_SUCCESS;
+    }
+    
+    if (strcmp (name, "SOIL_STORAGE") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr-> soil_reservoir.storage_m;
+        return BMI_SUCCESS;
+    }
     /***********************************************************/
     /***********    INPUT    ***********************************/
     /***********************************************************/

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -94,6 +94,7 @@ extern void cfe(
   massbal_struct->vol_et_to_atm = massbal_struct->vol_et_to_atm + evap_struct->actual_et_from_soil_m_per_timestep;
   massbal_struct->volout=massbal_struct->volout+evap_struct->actual_et_from_soil_m_per_timestep; 
   
+  evap_struct->actual_et_m_per_timestep=evap_struct->actual_et_from_rain_m_per_timestep+evap_struct->actual_et_from_soil_m_per_timestep;
   // LKC: This needs to be calcualted here after et_from_soil since soil_reservoir_struct->storage_m changes
   soil_reservoir_storage_deficit_m=(NWM_soil_params_struct.smcmax*NWM_soil_params_struct.D-soil_reservoir_struct->storage_m);
   


### PR DESCRIPTION
Adds Potential and Actual ET to bmi Output so we can test on ngen. For now, the standard names were not used since we cannot have variables with same names as output and input. We might want to change that in the future (including the other output variables). 

## Additions

Add two additional variables to bmi output: potential and actual evapotranspiration

## Removals

Nothing was removed. 

## Changes

-

## Testing

1. Tested with ./make_and_run_bmi_pass_forcings_pet.sh and in ngen

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [ x] Changes are limited to a single goal (no scope creep)
- [ x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ x] Passes all existing automated tests
- [ x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
