### PR TITLE
debugged. variable name (soil_moisture_deficit) was wrong

### DIFF
--- a/py_cfe/cfe.py
+++ b/py_cfe/cfe.py
@@ -52,7 +52,7 @@ class CFE():
             
         # ________________________________________________
         if cfe_state.previous_flux_perc_m > cfe_state.soil_reservoir_storage_deficit_m:
-            diff = cfe_state.previous_flux_perc_m - cfe_state.soil_reservoir_storage_deficit
+            diff = cfe_state.previous_flux_perc_m - cfe_state.soil_reservoir_storage_deficit_m
             cfe_state.infiltration_depth_m = cfe_state.soil_reservoir_storage_deficit_m
             cfe_state.vol_sch_runoff += diff
             cfe_state.vol_sch_infilt -= diff


### PR DESCRIPTION
## Changes
Changed the variable name 'soil_moisture_deficit' to 'soil_moisture_deficit_m'. 

I guess it was left unfound because the condition "cfe_state.previous_flux_perc_m > cfe_state.soil_reservoir_storage_deficit_m" was barely reached. Tested and working okay. 