### PR TITLE
incl params g/set value in bmi unit testing

### DIFF
--- a/test/main_unit_test_bmi.c
+++ b/test/main_unit_test_bmi.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <assert.h>
 #include "../include/cfe.h" 
 #include "../include/bmi.h" 
 #include "../include/bmi_cfe.h"
@@ -385,6 +386,25 @@ main(int argc, const char *argv[]){
     }
     free(names_out);
     free(names_in);
+
+    // JG Note: added 03.22.2022 to test added params get set values. 
+    // Params are not standard bmi i/o vars.
+    printf("\nTEST BMI MODEL PARAMETERS\n*************************\n");
+    //int expected_num_params = 5;
+    static const char *expected_param_names[10] = {"maxsmc", "satdk", "slope", "b", "multiplier", "Klf", 
+    "Kn", "Cgw", "expon", "max_gw_storage"}; 
+    double test_set_value = 4.2;
+    double test_get_value = 0.0;
+    for( int i = 0; i < 10; i++ ){
+        status = model->set_value(model, expected_param_names[i], &test_set_value);
+        //if (status == BMI_FAILURE)return BMI_FAILURE;
+        assert(status == BMI_SUCCESS);
+        status = model->get_value(model, expected_param_names[i], &test_get_value);
+        assert(status == BMI_SUCCESS);
+        assert(test_set_value == test_get_value);
+        printf(" get & set values match for parameter: %s \n", expected_param_names[i]);
+    }
+
     // Test BMI: CONTROL FUNCTION update_until()
 
     {


### PR DESCRIPTION
Simply tests `get_value()` and `set_value()` functions for newly added parameter variables (not input nor output).
Closes #54 

## Additions

- In[ bmi unit testing](https://github.com/NOAA-OWP/cfe/blob/4c8f6a8022ef243c00bd7a843e50d9f37b884a19/test/main_unit_test_bmi.c#L390), call get and set values for all 10 parameters and confirm values match. 


## Testing

1. make_and_run_bmi_unit_test.sh

## Screenshots
![image](https://user-images.githubusercontent.com/30940444/159783330-3bb49303-79eb-4488-bd2b-81bfa8e59cab.png)


