### PR TITLE
Fixed the main cause of missing baseflow. Variable name primary & secondary fluxes were not consistent

### DIFF
--- a/src/cfe.c
+++ b/src/cfe.c
@@ -65,8 +65,8 @@ extern void cfe(
     // LOCAL VARIABLES, the values of which are not important to describe the model state.  They are like notes on scrap paper.
  
     double diff=0.0;
-    double primary_flux=0.0;      // pointers to these variables passed to conceptual nonlinear reservoir which has two outlets, primary & secondary
-    double secondary_flux=0.0;    // pointers to these variables passed to conceptual nonlinear reservoir which has two outlets, primary & secondary
+    double primary_flux_m=0.0;      // pointers to these variables passed to conceptual nonlinear reservoir which has two outlets, primary & secondary
+    double secondary_flux_m=0.0;    // pointers to these variables passed to conceptual nonlinear reservoir which has two outlets, primary & secondary
     double lateral_flux=0.0;      // flux from soil to lateral flow Nash cascade +to cascade  [m/timestep]
     double percolation_flux=0.0;  // flux from soil to gw nonlinear researvoir, +downward  [m/timestep] 
     
@@ -204,10 +204,10 @@ extern void cfe(
   massbal_struct->vol_soil_to_lat_flow     += flux_lat_m;  //TODO add this to nash cascade as input
   massbal_struct->volout=massbal_struct->volout+flux_lat_m;
   
-  conceptual_reservoir_flux_calc(gw_reservoir_struct,&primary_flux,&secondary_flux);
+  conceptual_reservoir_flux_calc(gw_reservoir_struct,&primary_flux_m,&secondary_flux_m);
   
   
-  flux_from_deep_gw_to_chan_m=primary_flux;  // m/h   <<<<<<<<<< BASE FLOW FLUX >>>>>>>>>
+  flux_from_deep_gw_to_chan_m=primary_flux_m;  // m/h   <<<<<<<<<< BASE FLOW FLUX >>>>>>>>>
   if(flux_from_deep_gw_to_chan_m >  gw_reservoir_struct->storage_m)  {
   flux_from_deep_gw_to_chan_m=gw_reservoir_struct->storage_m;
   // TODO: set a flag when flux larger than storage
@@ -218,7 +218,7 @@ extern void cfe(
   massbal_struct->vol_from_gw+=flux_from_deep_gw_to_chan_m;
   
   // in the instance of calling the gw reservoir the secondary flux should be zero- verify
-  if(is_fabs_less_than_epsilon(secondary_flux,1.0e-09)==FALSE) printf("problem with nonzero flux point 1\n");
+  if(is_fabs_less_than_epsilon(secondary_flux_m,1.0e-09)==FALSE) printf("problem with nonzero flux point 1\n");
 
   
   // adjust state of deep groundwater conceptual nonlinear reservoir


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

Variable names were inconsistent. Fluxes from both soil & groundwater storages were named as primary_flux and secondary_flux in the main execusion vs. primary_flux**_m** and secoundary_flux**_m** in conceptual_reservoir_flux_calc. 

As a result, the baseflow was entirely missing in CFE. Fluxes calculated in conceptual_reservoir_flux_calc were not passed the main flux calculation.

I fixed the bug in the Python version on bmi-python, but here I am trying to make a similar pull request in the C version. 

## Changes
-  Changed variable name 'primary_flux' to 'primary_flux_m'
-  Changed variable name 'secondary_flux' to 'secondary_flux'
    On both soil and groundwater storage


## Testing

1. Not tested as I am not proficient in C. I appreciate somebody could check it. 
