### PR TITLE
XAJ zero params and initial storage_m bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ A [configs/](./configs/) directory contains primiary configuration text files fo
 | max_gw_storage | *double* |   |  meters [m] | parameter_adjustable |  | maximum storage in the conceptual reservoir |
 | Cgw | *double* |   |  meters/hour [m h-1] | parameter_adjustable |  | the primary outlet coefficient |
 | expon | *double* |   |   | parameter_adjustable |  | exponent parameter (1.0 for linear reservoir) |
-| gw_storage | *double* |   |  meters/meters [m/m] | parameter_adjustable |  | initial condition for groundwater reservoir |
+| gw_storage | *double* |   |  meters/meters [m/m] | parameter_adjustable |  | initial condition for groundwater reservoir - it is the ground water as a decimal fraction of the maximum groundwater storage (max_gw_storage) for the initial timestep |
 | alpha_fc | *double* |   |   | parameter_adjustable |  | field capacity |
-| soil_storage| *double* |   | meters/meters [m/m] | parameter_adjustable |  | initial condition for soil reservoir  |
+| soil_storage| *double* |   | meters/meters [m/m] | parameter_adjustable |  | initial condition for soil reservoir - it is the water in the soil as a decimal fraction of maximum soil water storage (smcmax * depth) for the initial timestep |
 | K_nash | *int* |   |   | parameter_adjustable |   | number of Nash lf reservoirs (optional, defaults to 2, ignored if storage values present)  |
 | K_lf | *double* |   |   | parameter_adjustable |  | Nash Config param - primary reservoir  |
 | nash_storage | *double* |   |   | parameter_adjustable |  | Nash Config param - secondary reservoir   |

--- a/configs/cat_87_bmi_config_cfe_pass.txt
+++ b/configs/cat_87_bmi_config_cfe_pass.txt
@@ -11,15 +11,9 @@ soil_params.expon_secondary=1.0[]
 max_gw_storage=0.25[m]
 Cgw=1.8e-05[m h-1]
 expon=6.0[]
-
-# gw_storage is the ground water as a decimal fraction of the maximum groundwater storage (max_gw_storage) for the initial timestep
 gw_storage=0.125[m/m]
-
 alpha_fc=0.33[]
-
-# soil_storage is the water in the soil as a decimal fraction of maximum soil water storage (smcmax * depth) for the initial timestep
 soil_storage=0.585626[m/m]
-
 K_nash=0.03[]
 K_lf=0.01[]
 nash_storage=0.0,0.0

--- a/configs/cat_87_bmi_config_cfe_pass.txt
+++ b/configs/cat_87_bmi_config_cfe_pass.txt
@@ -11,9 +11,15 @@ soil_params.expon_secondary=1.0[]
 max_gw_storage=0.25[m]
 Cgw=1.8e-05[m h-1]
 expon=6.0[]
+
+# gw_storage is the ground water as a decimal fraction of the maximum groundwater storage (max_gw_storage) for the initial timestep
 gw_storage=0.125[m/m]
+
 alpha_fc=0.33[]
+
+# soil_storage is the water in the soil as a decimal fraction of maximum soil water storage (smcmax * depth) for the initial timestep
 soil_storage=0.585626[m/m]
+
 K_nash=0.03[]
 K_lf=0.01[]
 nash_storage=0.0,0.0

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -586,7 +586,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model, doubl
             continue;
         }
         if (strcmp(param_key, "gw_storage") == 0) {
-            model->gw_reservoir.storage_m = strtod(param_value, NULL);
+            model->gw_reservoir.storage_m = strtod(param_value, NULL) * model->gw_reservoir.storage_max_m; //edited by RLM to fix units from [m/m] to [m]
             is_gw_storage_set = TRUE;
             // Check if units are present and print warning if missing from config file
             if ((param_units == NULL) || (strlen(param_units) < 1)) {
@@ -2665,7 +2665,7 @@ extern void init_soil_reservoir(cfe_state_struct* cfe_ptr, double alpha_fc, doub
 
     // Negative amounts are always ignored and just considered emtpy
     if (storage < 0.0) storage = 0.0;
-    cfe_ptr->soil_reservoir.storage_m = storage;
+    cfe_ptr->soil_reservoir.storage_m = storage * cfe_ptr->NWM_soil_params.smcmax * cfe_ptr->NWM_soil_params.D; //edited by RLM to fix units from [m/m] to [m] in storage_m
 
     //cfe_ptr->soil_reservoir.storage_m = init_reservoir_storage(is_storage_ratios, storage, max_storage);
 }


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

- logic block in Xinanjiang routine to work when parameters are zero.  Assumes 95% runoff in these cases.
- description of gw_storage and soil_storage in config file cat_87_bmi_config_cfe_pass


## Changes

- fixed initial groundwater storage_m and soil water storage_m from [m/m] to [m] by multiplying the decimal fraction provided in the config file by the max storage in their respective reservoirs.

## Testing

1. Passes mass balance checks when the parameters (smcmax and/or soil_storage) are set to zero (catchment 87). Expected change can be seen in runoff
2. Passes mass balance checks with original parameter set (catchment 87)

## Screenshots
Original parameter set
![image](https://user-images.githubusercontent.com/61248457/181267826-f48617e8-df28-4ef6-b278-34b9f624d9e2.png)


smcmax set to zero
![image](https://user-images.githubusercontent.com/61248457/181268591-b4f9fac2-715f-4fa2-a54b-95505893c801.png)




## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
