### PR TITLE
Changed a solver for a soil moisture reservoir to prevent over-extraction of water by primary fluxes

### DIFF
--- a/cfe.py
+++ b/cfe.py
@@ -102,7 +102,7 @@ class CFE():
         cfe_state.vol_from_gw += cfe_state.flux_from_deep_gw_to_chan_m
         
         # ________________________________________________        
-        if not self.is_fabs_less_than_epsilon(cfe_state.secondary_flux, 1.0e-09):
+        if not self.is_fabs_less_than_epsilon(cfe_state.secondary_flux_m, 1.0e-09):
             print("problem with nonzero flux point 1\n")
                         
         # ________________________________________________                               

--- a/cfe.py
+++ b/cfe.py
@@ -2,6 +2,7 @@ import time
 import numpy as np
 import pandas as pd
 
+
 class CFE():
     def __init__(self):
         super(CFE, self).__init__()

--- a/cfe.py
+++ b/cfe.py
@@ -1,7 +1,36 @@
 import time
 import numpy as np
 import pandas as pd
+from scipy.integrate import odeint
+import math
 
+def conceptual_reservoir_flux_calc(t, S, storage_threshold_primary_m, storage_max_m, coeff_primary, coeff_secondary, PET, infilt, wltsmc):
+    # ODE of soil moisture reservoir mass balance
+    storage_above_threshold_m = S - storage_threshold_primary_m
+    storage_diff = storage_max_m - storage_threshold_primary_m
+    storage_ratio = np.minimum(storage_above_threshold_m / storage_diff, 1)
+
+    perc_lat_switch = np.multiply(S - storage_threshold_primary_m > 0, 1)
+    ET_switch = np.multiply(S - wltsmc > 0, 1)
+
+    storage_above_threshold_m_paw = S - wltsmc
+    storage_diff_paw = storage_threshold_primary_m - wltsmc
+    storage_ratio_paw = np.minimum(storage_above_threshold_m_paw/storage_diff_paw, 1) # Equation 11 (Ogden's document).
+
+    dS = infilt -1 * perc_lat_switch * (coeff_primary + coeff_secondary) * storage_ratio - ET_switch * PET * storage_ratio_paw
+    return dS
+
+def jac(t, S, storage_threshold_primary_m, storage_max_m, coeff_primary, coeff_secondary, PET, infilt, wltsmc):
+    # Jacobian matrix for the conceptual_reservoir_flux_calc
+    storage_diff = storage_max_m - storage_threshold_primary_m
+
+    perc_lat_switch = np.multiply(S - storage_threshold_primary_m > 0, 1)
+    ET_switch = np.multiply((S - wltsmc > 0) and (S - storage_threshold_primary_m < 0), 1)
+
+    storage_diff_paw = storage_threshold_primary_m - wltsmc
+
+    dfdS = -1 * perc_lat_switch * (coeff_primary + coeff_secondary) * 1/storage_diff - ET_switch * PET * 1/storage_diff_paw
+    return [dfdS]
 
 class CFE():
     def __init__(self):
@@ -16,11 +45,18 @@ class CFE():
         
         # ________________________________________________
         cfe_state.potential_et_m_per_timestep = cfe_state.potential_et_m_per_s * cfe_state.time_step_size
-        
+        cfe_state.reduced_potential_et_m_per_timestep =  cfe_state.potential_et_m_per_s * cfe_state.time_step_size
+        cfe_state.vol_PET += cfe_state.potential_et_m_per_timestep
+
         # ________________________________________________
         # SUBROUTINE
         # timestep_rainfall_input_m = f(timestep_rainfall_input_m, potential_et_m_per_timestep)
+        cfe_state.actual_et_from_rain_m_per_timestep = 0
         self.et_from_rainfall(cfe_state)
+
+        cfe_state.vol_et_from_rain += cfe_state.actual_et_from_rain_m_per_timestep
+        cfe_state.vol_et_to_atm += cfe_state.actual_et_from_rain_m_per_timestep
+        cfe_state.volout += cfe_state.actual_et_from_rain_m_per_timestep
         
         # ________________________________________________        
         cfe_state.soil_reservoir_storage_deficit_m = (cfe_state.soil_params['smcmax'] * \
@@ -53,34 +89,38 @@ class CFE():
             
         # ________________________________________________
         if cfe_state.previous_flux_perc_m > cfe_state.soil_reservoir_storage_deficit_m:
-            diff = cfe_state.previous_flux_perc_m - cfe_state.soil_reservoir_storage_deficit_m
+            self.diff_infilt = cfe_state.previous_flux_perc_m - cfe_state.soil_reservoir_storage_deficit_m
             cfe_state.infiltration_depth_m = cfe_state.soil_reservoir_storage_deficit_m
-            cfe_state.vol_sch_runoff += diff
-            cfe_state.vol_sch_infilt -= diff
-            cfe_state.surface_runoff_depth_m += diff
+            cfe_state.vol_sch_runoff += self.diff_infilt
+            cfe_state.vol_sch_infilt -= self.diff_infilt
+            cfe_state.surface_runoff_depth_m += self.diff_infilt
             
         # ________________________________________________
-        cfe_state.vol_to_soil += cfe_state.infiltration_depth_m
-        cfe_state.soil_reservoir['storage_m'] += cfe_state.infiltration_depth_m
-
-        # ________________________________________________
         # SUBROUTINE
-        # primary_flux, secondary_flux = f(reservoir)
-        self.conceptual_reservoir_flux_calc(cfe_state, cfe_state.soil_reservoir)
+        # Solve ODE for the soil reservoir
+        # Calculates primary_flux, secondary_flux, AET, and infiltration simultaneously
+        cfe_state.actual_et_from_soil_m_per_timestep = 0
+        self.soil_reservoir_flux_calc(cfe_state, cfe_state.soil_reservoir)
 
         # ________________________________________________
         cfe_state.flux_perc_m = cfe_state.primary_flux_m
         cfe_state.flux_lat_m = cfe_state.secondary_flux_m
+        cfe_state.vol_to_soil += cfe_state.infiltration_depth_m
+        cfe_state.vol_et_from_soil += cfe_state.actual_et_from_soil_m_per_timestep
+        cfe_state.vol_et_to_atm += cfe_state.actual_et_from_soil_m_per_timestep
+        cfe_state.volout += cfe_state.actual_et_from_soil_m_per_timestep
 
         # ________________________________________________
-        cfe_state.gw_reservoir_storage_deficit_m = cfe_state.gw_reservoir['storage_max_m'] - cfe_state.gw_reservoir['storage_m']
-        
+        cfe_state.gw_reservoir_storage_deficit_m = cfe_state.gw_reservoir['storage_max_m'] - cfe_state.gw_reservoir[
+            'storage_m']
+
         # ________________________________________________
         if cfe_state.flux_perc_m > cfe_state.gw_reservoir_storage_deficit_m:
-            diff = cfe_state.flux_perc_m - cfe_state.gw_reservoir_storage_deficit_m
+            # (?) When the groundwater storage is full, the overflowing amount goes to direct runoff?
+            self.diff_perc = cfe_state.flux_perc_m - cfe_state.gw_reservoir_storage_deficit_m
             cfe_state.flux_perc_m = cfe_state.gw_reservoir_storage_deficit_m
-            cfe_state.vol_sch_runoff+=diff 
-            cfe_state.vol_sch_infilt-=diff 
+            cfe_state.vol_sch_runoff += self.diff_perc
+            cfe_state.vol_sch_infilt -= self.diff_perc
             
         # ________________________________________________
         cfe_state.vol_to_gw                += cfe_state.flux_perc_m
@@ -90,7 +130,7 @@ class CFE():
         cfe_state.soil_reservoir['storage_m'] -= cfe_state.flux_perc_m
         cfe_state.soil_reservoir['storage_m'] -= cfe_state.flux_lat_m
         cfe_state.vol_soil_to_lat_flow        += cfe_state.flux_lat_m  #TODO add this to nash cascade as input
-        cfe_state.volout                       = cfe_state.volout + cfe_state.flux_lat_m;
+        cfe_state.volout                      += cfe_state.flux_lat_m
 
             
         # ________________________________________________
@@ -203,21 +243,102 @@ class CFE():
         """
             iff it is raining, take PET from rainfall first.  Wet veg. is efficient evaporator.
         """
-        
-        if cfe_state.timestep_rainfall_input_m >0.0:
 
+        if cfe_state.timestep_rainfall_input_m > 0.0:
             if cfe_state.timestep_rainfall_input_m > cfe_state.potential_et_m_per_timestep:
-        
-                cfe_state.actual_et_m_per_timestep = cfe_state.potential_et_m_per_timestep
-                cfe_state.timestep_rainfall_input_m -= cfe_state.actual_et_m_per_timestep
 
-            else: 
+                cfe_state.actual_et_from_rain_m_per_timestep = cfe_state.potential_et_m_per_timestep
+                cfe_state.timestep_rainfall_input_m -= cfe_state.actual_et_from_rain_m_per_timestep
 
-                cfe_state.potential_et_m_per_timestep -= cfe_state.timestep_rainfall_input_m
-                cfe_state.timestep_rainfall_input_m=0.0
+            else:
+                cfe_state.actual_et_from_rain_m_per_timestep = cfe_state.timestep_rainfall_input_m
+                cfe_state.timestep_rainfall_input_m = 0.0
+
+        cfe_state.reduced_potential_et_m_per_timestep = cfe_state.potential_et_m_per_timestep - cfe_state.actual_et_from_rain_m_per_timestep
+
         return
                 
-                
+
+    def soil_reservoir_flux_calc(self, cfe_state, reservoir):
+        """
+        This function solves ODE for a soil reservoir
+        :param cfe_state:
+        :param reservoir:
+        :return: reservoir['storage_m']
+        """
+
+        # Initialization
+        y0 = [reservoir['storage_m']]
+
+        t = np.array([0, 0.05, 0.15, 0.3, 0.6, 1.0])
+
+        # Solve ODE
+        sol = odeint(
+            conceptual_reservoir_flux_calc,
+            y0,
+            t,
+            args=(
+                reservoir['storage_threshold_primary_m'],
+                reservoir['storage_max_m'],
+                reservoir['coeff_primary'],
+                reservoir['coeff_secondary'],
+                cfe_state.reduced_potential_et_m_per_timestep,
+                cfe_state.infiltration_depth_m,
+                cfe_state.soil_params['wltsmc']
+            ),
+            tfirst=True,
+            Dfun=jac
+        )
+
+        # Finalize the results
+        ts_concat = t
+        ys_concat = np.concatenate(sol, axis=0)
+
+        # Calculate fluxes (fine-tuning the residuals by scaling)
+        t_proportion = np.diff(ts_concat)
+        ys_avg = np.convolve(ys_concat, np.ones(2), 'valid') / 2
+
+        lateral_flux = np.zeros(ys_avg.shape)
+        perc_lat_switch = ys_avg - reservoir['storage_threshold_primary_m'] > 0
+        lateral_flux[perc_lat_switch] = reservoir['coeff_secondary'] * np.minimum(
+            (ys_avg[perc_lat_switch] - reservoir['storage_threshold_primary_m']) / (
+                        reservoir['storage_max_m'] - reservoir['storage_threshold_primary_m']), 1)
+        lateral_flux_frac = lateral_flux * t_proportion
+
+        perc_flux = np.zeros(ys_avg.shape)
+        perc_flux[perc_lat_switch] = reservoir['coeff_primary'] * np.minimum(
+            (ys_avg[perc_lat_switch] - reservoir['storage_threshold_primary_m']) / (
+                        reservoir['storage_max_m'] - reservoir['storage_threshold_primary_m']), 1)
+        perc_flux_frac = perc_flux * t_proportion
+
+        et_from_soil = np.zeros(ys_avg.shape)
+        ET_switch = ys_avg - cfe_state.soil_params['wltsmc'] > 0
+        et_from_soil[ET_switch] = cfe_state.reduced_potential_et_m_per_timestep * np.minimum(
+            (ys_avg[ET_switch] - cfe_state.soil_params['wltsmc']) / (reservoir['storage_threshold_primary_m'] - cfe_state.soil_params['wltsmc']), 1)
+        et_from_soil_frac = et_from_soil * t_proportion
+
+        infilt_to_soil = np.repeat(cfe_state.infiltration_depth_m, ys_avg.shape)
+        infilt_to_soil_frac = infilt_to_soil * t_proportion
+
+        # Scale fluxes
+        sum_outflux = lateral_flux_frac + perc_flux_frac + et_from_soil_frac
+        if sum_outflux.any() == 0:
+            flux_scale = 0
+        else:
+            flux_scale = np.zeros(infilt_to_soil_frac.shape)
+            flux_scale[sum_outflux != 0] = (np.diff(-ys_concat, axis=0)[sum_outflux != 0] + infilt_to_soil_frac[
+                sum_outflux != 0]) / sum_outflux[sum_outflux != 0]
+            flux_scale[sum_outflux == 0] = 0
+        scaled_lateral_flux = lateral_flux_frac * flux_scale
+        scaled_perc_flux = perc_flux_frac * flux_scale
+        scaled_et_flux = et_from_soil_frac * flux_scale
+
+        # Return the results
+        cfe_state.primary_flux_m = math.fsum(scaled_perc_flux)
+        cfe_state.secondary_flux_m = math.fsum(scaled_lateral_flux)
+        cfe_state.actual_et_from_soil_m_per_timestep = math.fsum(scaled_et_flux)
+        reservoir['storage_m'] = ys_concat[-1]
+
     # __________________________________________________________________________________________________________
     ########## SINGLE OUTLET EXPONENTIAL RESERVOIR ###############
     ##########                -or-                 ###############
@@ -333,36 +454,35 @@ class CFE():
             
                                
     # __________________________________________________________________________________________________________
-    def et_from_soil(self,cfe_state):
+    def et_from_soil(self, cfe_state):
         """
             take AET from soil moisture storage, 
             using Budyko type curve to limit PET if wilting<soilmoist<field_capacity
         """
-        
-        if cfe_state.potential_et_m_per_timestep > 0:
-            
-            print("this should not happen yet. Still debugging the other functions.")
-            
+
+        if cfe_state.reduced_potential_et_m_per_timestep > 0:
             if cfe_state.soil_reservoir['storage_m'] >= cfe_state.soil_reservoir['storage_threshold_primary_m']:
-            
-                cfe_state.actual_et_m_per_timestep = np.min(cfe_state.potential_et_m_per_timestep, 
-                                                       cfe_state.soil_reservoir['storage_m'])
 
-                cfe_state.soil_reservoir['storage_m'] -= cfe_state.actual_et_m_per_timestep
+                cfe_state.actual_et_from_soil_m_per_timestep = np.minimum(cfe_state.reduced_potential_et_m_per_timestep,
+                                                                          cfe_state.soil_reservoir['storage_m'])
 
-                cfe_state.et_struct['potential_et_m_per_timestep'] = 0.0
-                               
-            elif (cfe_state.soil_reservoir['storage_m'] > cfe_state.soil_reservoir['wilting_point_m'] and 
+            elif (cfe_state.soil_reservoir['storage_m'] > cfe_state.soil_params['wltsmc'] * cfe_state.soil_params[
+                'D'] and
                   cfe_state.soil_reservoir['storage_m'] < cfe_state.soil_reservoir['storage_threshold_primary_m']):
-            
-                Budyko_numerator = cfe_state.soil_reservoir['storage_m'] - cfe_state.soil_reservoir['wilting_point_m']
+
+                Budyko_numerator = cfe_state.soil_reservoir['storage_m'] - cfe_state.soil_params['wltsmc'] * \
+                                   cfe_state.soil_params['D']
                 Budyko_denominator = cfe_state.soil_reservoir['storage_threshold_primary_m'] - \
-                                     cfe_state.soil_reservoir['wilting_point_m']
-                Budyki = Budyko_numerator / Budyko_denominator
-                               
-                cfe_state.actual_et_m_per_timestep = Budyko * cfe_state.potential_et_m_per_timestep
-                               
-                cfe_state.soil_reservoir['storage_m'] -= cfe_state.actual_et_m_per_timestep
+                                     cfe_state.soil_params['wltsmc'] * cfe_state.soil_params['D']
+                Budyko = Budyko_numerator / Budyko_denominator
+
+                cfe_state.actual_et_from_soil_m_per_timestep = np.minimum(
+                    Budyko * cfe_state.reduced_potential_et_m_per_timestep,
+                    cfe_state.soil_reservoir['storage_m'])
+
+            cfe_state.soil_reservoir['storage_m'] -= cfe_state.actual_et_from_soil_m_per_timestep
+            cfe_state.reduced_potential_et_m_per_timestep -= cfe_state.actual_et_from_soil_m_per_timestep
+
         return
             
             

--- a/cfe.py
+++ b/cfe.py
@@ -2,6 +2,7 @@ import time
 import numpy as np
 import pandas as pd
 
+
 class CFE():
     def __init__(self):
         super(CFE, self).__init__()
@@ -68,8 +69,8 @@ class CFE():
         self.conceptual_reservoir_flux_calc(cfe_state, cfe_state.soil_reservoir)
 
         # ________________________________________________
-        cfe_state.flux_perc_m = cfe_state.primary_flux
-        cfe_state.flux_lat_m = cfe_state.secondary_flux
+        cfe_state.flux_perc_m = cfe_state.primary_flux_m
+        cfe_state.flux_lat_m = cfe_state.secondary_flux_m
 
         # ________________________________________________
         cfe_state.gw_reservoir_storage_deficit_m = cfe_state.gw_reservoir['storage_max_m'] - cfe_state.gw_reservoir['storage_m']
@@ -98,7 +99,7 @@ class CFE():
         self.conceptual_reservoir_flux_calc(cfe_state, cfe_state.gw_reservoir) 
             
         # ________________________________________________
-        cfe_state.flux_from_deep_gw_to_chan_m = cfe_state.primary_flux
+        cfe_state.flux_from_deep_gw_to_chan_m = cfe_state.primary_flux_m
         cfe_state.vol_from_gw += cfe_state.flux_from_deep_gw_to_chan_m
         
         # ________________________________________________        

--- a/cfe.py
+++ b/cfe.py
@@ -2,7 +2,6 @@ import time
 import numpy as np
 import pandas as pd
 
-
 class CFE():
     def __init__(self):
         super(CFE, self).__init__()


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Current behavior
- There was an issue in the soil conceptual reservoir: **the secondary fluxes was constantly zero**. This was because **the primary flux was over-extracting** water from the soil reservoir, and there was no water left for the secondary fluxes.
- The root cause of the problem was in **the numerical solver**: the model before this commit was extracting fluxes from the soil reservoir in order (ET -> primary flux -> secondary flux), and the secondary fluxes are calculated based on soil water storage remaining after ET and primary flux used up the soil water storage. This "extracting in order" method does not work unless the time step is super fina e (like 1-minute interval or so).  

## Expected behavior
- The solution is to **use ODE for the soil reservoir**. With this, the fluxes from the soil reservoir (ET, primary, and secondary flux) are extracted simultaneously with a finer timestep (but not too fine). Adding this ODE slows the calculation but fixes the unrealistic soil moisture reservoir behavior. 

## Additions
- Added an ODE solving module for the soil moisture conceptual reservoir calculation. The main functions/methods added are: `conceptual_reservoir_flux_calc`, `jac`, and `soil_reservoir_flux_calc`. 

## Changes
- Some variables are added or changed according to this change (e.g. diff_infilt, diff_perc, ) 

## Deletions
- A few lines of code that compares groundwater water deficit and percolation are removed (the ones starting from `cfe_state.previous_flux_perc_m > cfe_state.soil_reservoir_storage_deficit_m`), because the ODE will solve the issue of excess percolation without those lines 
- A method `et_from_soil` is removed, and incorporated into the `soil_reservoir_flux_calc`
 
## Testing
1. Visually checked plots, checked mass balance by running run_massbalance_cfe.py (water balance is fixed by my commit on Sept 22th)

## Notes
- Calculation time, unfortunately, slows down according to this change. My test case took 30 seconds to calculate 3 years of record. To minimize the calculation time, I **tested different solvers** and picked the best one, as well as added **the jacobian matrix**. 
- Currently the code uses the scipy odeint for ODE solver, which uses the LSODA algorithm. The rationale behind it is that (1) an ODE solver for stiff system was needed as the target system (soil moisture reservoir) can be unstable around the thresholds (2) an ODE solver that does not take too much computational time was preferred; LSODA switches between stiff and non-stiff methods, which saves computational time. Note that there are potential ODE solver options, such as to use solve_ivp, and try different ODE solver scheme for better accuracy in water balance. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support
- [x] Windows
- [ ] Linux
- [ ] Browser
