### PR TITLE
close initialization file after reading to avoid resource leak

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -916,7 +916,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model, doubl
         for (j = 0; j < num_nash_lf; j++)
             model->nash_storage[j] = 0.0;
     }
-
+    fclose(fp);
 #if CFE_DEGUG >= 1
     printf("Finished function parsing CFE config\n");
 #endif


### PR DESCRIPTION
The bmi initialization code leaks the file handle from the `fopen` call.  Especially in the ngen case where this be initialized many times, this leads to an exhaustion of open file handles on the system can cause it to crash.  Fixes #67.

## Changes

- Close the file handle after reading of file is complete

## Testing

1. Tested with ngen

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
