### PR TITLE
Adding external submodules for aorc forcing code 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/forcing_code"]
+	path = extern/forcing_code
+	url = https://github.com/NOAA-OWP/aorc_bmi.git

--- a/make_and_run_bmi_pass_forcings.sh
+++ b/make_and_run_bmi_pass_forcings.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-gcc -lm ./src/main_pass_forcings.c ./src/cfe.c ./src/bmi_cfe.c ./forcing_code/src/aorc.c ./forcing_code/src/bmi_aorc.c  -o run_cfe_bmi_pass_forcings
+gcc -lm ./src/main_pass_forcings.c ./src/cfe.c ./src/bmi_cfe.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c  -o run_cfe_bmi_pass_forcings
 ./run_cfe_bmi_pass_forcings ./configs/cat_87_bmi_config_cfe_pass.txt ./configs/cat_87_bmi_config_aorc.txt

--- a/make_and_run_bmi_pass_forcings_pet.sh
+++ b/make_and_run_bmi_pass_forcings_pet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-gcc ./src/main_cfe_aorc_pet.c ./forcing_code/src/pet.c ./forcing_code/src/bmi_pet.c ./src/cfe.c ./src/bmi_cfe.c ./forcing_code/src/aorc.c ./forcing_code/src/bmi_aorc.c -o run_cfe_aorc_et_bmi -lm 
+gcc ./src/main_cfe_aorc_pet.c ./forcing_code/src/pet.c ./forcing_code/src/bmi_pet.c ./src/cfe.c ./src/bmi_cfe.c ./extern/forcing_code/src/aorc.c ./extern/forcing_code/src/bmi_aorc.c -o run_cfe_aorc_et_bmi -lm 
 ./run_cfe_aorc_et_bmi ./configs/cat_87_bmi_config_cfe_pass.txt ./configs/cat_87_bmi_config_aorc.txt ./configs/cat_87_bmi_config_pet_pass.txt

--- a/src/main_cfe_aorc_pet.c
+++ b/src/main_cfe_aorc_pet.c
@@ -6,8 +6,8 @@
 #include "../include/bmi_cfe.h"
 #include "../forcing_code/include/pet.h"
 #include "../forcing_code/include/bmi_pet.h"
-#include "../forcing_code/include/aorc.h"
-#include "../forcing_code/include/bmi_aorc.h"
+#include "../extern/forcing_code/include/aorc.h"
+#include "../extern/forcing_code/include/bmi_aorc.h"
 
 /***************************************************************
     Function to pass PET to CFE using BMI.

--- a/src/main_pass_forcings.c
+++ b/src/main_pass_forcings.c
@@ -5,8 +5,8 @@
 #include "../include/bmi.h"
 #include "../include/bmi_cfe.h"
 
-#include "../forcing_code/include/aorc.h"
-#include "../forcing_code/include/bmi_aorc.h"
+#include "../extern/forcing_code/include/aorc.h"
+#include "../extern/forcing_code/include/bmi_aorc.h"
 
 /***************************************************************
     Function to pass the forcing data from AORC to CFE using BMI.


### PR DESCRIPTION
##  Changes to be committed:

- A       .gitmodules
- A       extern/forcing_code
- D       forcing_code/include/aorc.h
- D       forcing_code/include/aorc_tools.h
- D       forcing_code/include/bmi_aorc.h
- D       forcing_code/src/aorc.c
- D       forcing_code/src/bmi_aorc.c
- M       make_and_run_bmi_pass_forcings.sh
- M       make_and_run_bmi_pass_forcings_pet.sh
- M       src/main_cfe_aorc_pet.c
- M       src/main_pass_forcings.c


## Additions
-       .gitmodules
-       extern/forcing_code

## Removals

-       forcing_code/include/aorc.h
-       forcing_code/include/aorc_tools.h
-       forcing_code/include/bmi_aorc.h
-       forcing_code/src/aorc.c
-       forcing_code/src/bmi_aorc.c


## Changes

-       make_and_run_bmi_pass_forcings.sh
-       make_and_run_bmi_pass_forcings_pet.sh
-       src/main_cfe_aorc_pet.c
-       src/main_pass_forcings.c


## Testing



## Screenshots


## Notes

- Need further path modifications for some files after removing the rest of the forcing_code directory from the main level and adding PET as an external submodule.  


## Todos



## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
