### PR TITLE
added_realization_file

### DIFF
--- a/configs/realization_cfe_pet.json
+++ b/configs/realization_cfe_pet.json
@@ -1,0 +1,83 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_noahowp_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "Q_OUT",
+                    "modules": [
+			{
+			    "name": "bmi_c++",
+			    "params": {
+                                "model_type_name": "bmi_c++_sloth",
+                                "library_file": "./extern/sloth/cmake_build/libslothmodel",
+                                "init_config": "/dev/null",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "z",
+                                "uses_forcing_file": false,
+                                "model_params": {
+				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_smp(1,double,1,node)": 0.0
+                                }
+			    }
+                        },
+                        {
+			    "name": "bmi_c",
+			    "params": {
+                                "model_type_name": "bmi_c_pet",
+                                "library_file": "./extern/evapotranspiration/cmake_build/libpetbmi",
+                                "forcing_file": "",
+                                "init_config": "./extern/cfe/cfe/configs/cat_87_bmi_config_pet_pass.txt",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "water_potential_evaporation_flux",
+                                "registration_function":"register_bmi_pet",
+                                    "uses_forcing_file": false
+			    }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_cfe",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi",
+                                "forcing_file": "",
+                                "init_config": "./extern/cfe/cfe/configs/cat_87_bmi_config_cfe_pass.txt",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "Q_OUT",
+                                "registration_function": "register_bmi_cfe",
+                                "variables_names_map": {
+				    "water_potential_evaporation_flux" : "water_potential_evaporation_flux",
+				    "atmosphere_water__liquid_equivalent_precipitation_rate" : "APCP_surface",
+				    "atmosphere_air_water~vapor__relative_saturation" : "SPFH_2maboveground",
+				    "land_surface_air__temperature" : "TMP_2maboveground",
+				    "land_surface_wind__x_component_of_velocity" : "UGRD_10maboveground",
+				    "land_surface_wind__y_component_of_velocity" : "VGRD_10maboveground",
+				    "land_surface_radiation~incoming~longwave__energy_flux" : "DLWRF_surface",
+				    "land_surface_radiation~incoming~shortwave__energy_flux" : "DSWRF_surface",
+				    "land_surface_air__pressure" : "PRES_surface",
+				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "soil_moisture_profile" : "sloth_smp"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+	    "path" : "./extern/cfe/cfe/forcings/cat87_01Dec2015-.csv"
+        }
+    },
+    "time": {
+        "start_time": "2015-12-01 00:00:00",
+        "end_time": "2015-12-30 23:00:00",
+        "output_interval": 3600
+    }
+}


### PR DESCRIPTION
Added a local nextgen realization file, a comparable example file of cfe with `FORCINGPET` pseudo-framework test. This allows us to directly compare the CFE pseudo-framework and ngen results.

## Additions
- no additions to the code

## Removals
- no removals

## Changes
- no changes

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: