### PR TITLE
changed_bmi_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The user has the option to turn ON and OFF rootzone-based AET, default option is
 
 ## Soil freeze-thaw model (SFT)
 The Soil Freeze-Thaw (SFT) model is a standalone model.  For detailed information please refer to the [SFT repo](https://github.com/NOAA-OWP/SoilFreezeThaw). A few things to note when coupling SFT to CFE:
-1. SFT model provides `ice fraction` to CFE runoff schemes (Schaake `ice_fraction_schaake` and Xinanjiang `ice_fraction_xinan`)
+1. SFT model provides `ice fraction` to CFE runoff schemes (Schaake `ice_fraction_schaake` and Xinanjiang `ice_fraction_xinanjiang`)
 2. To turn ON/OFF SFT set sft_coupled flag.
     * `sft_coupled` : (type boolean) if `true`, SFT is turned ON. (options: True, true, 1).
     * If the runoff scheme is Xinanjiang, no additional parameters are needed in the CFE config files.

--- a/configs/realization_cfe_pet.json
+++ b/configs/realization_cfe_pet.json
@@ -21,7 +21,7 @@
                                 "uses_forcing_file": false,
                                 "model_params": {
 				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
-				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_ice_fraction_xinanjiang(1,double,1,node)": 0.0,
 				    "sloth_smp(1,double,1,node)": 0.0
                                 }
 			    }
@@ -60,7 +60,7 @@
 				    "land_surface_radiation~incoming~shortwave__energy_flux" : "DSWRF_surface",
 				    "land_surface_air__pressure" : "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinanZ" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinanjiang",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
@@ -76,9 +76,8 @@
         }
     },
     "time": {
-        "start_time": "2015-12-01 00:00:00",	
-	"end_time": "2015-12-01 01:00:00",
-        "#end_time": "2015-12-30 23:00:00",
+        "start_time": "2015-12-01 00:00:00",
+        "end_time": "2015-12-30 23:00:00",
         "output_interval": 3600
     }
 }

--- a/configs/realization_cfe_pet.json
+++ b/configs/realization_cfe_pet.json
@@ -60,7 +60,7 @@
 				    "land_surface_radiation~incoming~shortwave__energy_flux" : "DSWRF_surface",
 				    "land_surface_air__pressure" : "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanZ" : "sloth_ice_fraction_xinan",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false
@@ -76,8 +76,9 @@
         }
     },
     "time": {
-        "start_time": "2015-12-01 00:00:00",
-        "end_time": "2015-12-30 23:00:00",
+        "start_time": "2015-12-01 00:00:00",	
+	"end_time": "2015-12-01 01:00:00",
+        "#end_time": "2015-12-30 23:00:00",
         "output_interval": 3600
     }
 }

--- a/include/cfe.h
+++ b/include/cfe.h
@@ -151,7 +151,7 @@ extern void Schaake_partitioning_scheme(double dt, double field_capacity_m, doub
 extern void Xinanjiang_partitioning_scheme(double water_input_depth_m, double field_capacity_m,
 					   double max_soil_moisture_storage_m, double column_total_soil_water_m,
 					   struct direct_runoff_parameters_structure *parms, double *surface_runoff_depth_m,
-					   double *infiltration_depth_m, double ice_fraction_xinan);
+					   double *infiltration_depth_m, double ice_fraction_xinanjiang);
 
 extern double convolution_integral(double runoff_m, int num_giuh_ordinates, 
                                    double *giuh_ordinates, double *runoff_queue_m_per_timestep);

--- a/include/conceptual_reservoir.h
+++ b/include/conceptual_reservoir.h
@@ -26,7 +26,7 @@ struct conceptual_reservoir {
   double storage_threshold_secondary_m;
   double coeff_secondary;
   double exponent_secondary;
-  double ice_fraction_schaake, ice_fraction_xinan;
+  double ice_fraction_schaake, ice_fraction_xinanjiang;
   int   is_sft_coupled; // boolean - true if SFT is ON otherwise OFF (default is OFF)
   
   //---Root zone adjusted AET development -rlm -ahmad -------------

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -62,7 +62,7 @@ Variable var_info[] = {
 	{ 12, "coeff_secondary",                  "double", 1 },
 	{ 13, "exponent_secondary",               "double", 1 },
 	{ 14, "ice_fraction_schaake",	          "double", 1}, /* input from Soil Freeze-thaw model */
-	{ 15, "ice_fraction_xinan",	          "double", 1}, /* input from Soil Freeze-thaw model */
+	{ 15, "ice_fraction_xinanjiang",	  "double", 1}, /* input from Soil Freeze-thaw model */
 	//------------------------------
 	// Vars in gw reservoir struct
 	// type: conceptual_reservoir
@@ -279,7 +279,7 @@ static const char *input_var_names[INPUT_VAR_NAME_COUNT] = {
         "atmosphere_water__liquid_equivalent_precipitation_rate",
         "water_potential_evaporation_flux",
 	"ice_fraction_schaake",
-	"ice_fraction_xinan",
+	"ice_fraction_xinanjiang",
 	"soil_moisture_profile"
 };
 
@@ -1302,8 +1302,8 @@ static int Initialize (Bmi *self, const char *file)
     // Set all the mass balance trackers to zero.
     initialize_volume_trackers(cfe_bmi_data_ptr);
 
-    cfe_bmi_data_ptr->soil_reservoir.ice_fraction_schaake = 0.0;
-    cfe_bmi_data_ptr->soil_reservoir.ice_fraction_xinan = 0.0;
+    cfe_bmi_data_ptr->soil_reservoir.ice_fraction_schaake    = 0.0;
+    cfe_bmi_data_ptr->soil_reservoir.ice_fraction_xinanjiang = 0.0;
 
     if (cfe_bmi_data_ptr->soil_reservoir.aet_root_zone == TRUE)
       cfe_bmi_data_ptr->soil_reservoir.smc_profile = malloc(sizeof(double)*cfe_bmi_data_ptr->soil_reservoir.n_soil_layers);
@@ -1899,10 +1899,10 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         *dest = (void*)&cfe_ptr->soil_reservoir.ice_fraction_schaake;
         return BMI_SUCCESS;
     }
-    if (strcmp (name, "ice_fraction_xinan") == 0) {
+    if (strcmp (name, "ice_fraction_xinanjiang") == 0) {
         cfe_state_struct *cfe_ptr;
         cfe_ptr = (cfe_state_struct *) self->data;
-        *dest = (void*)&cfe_ptr->soil_reservoir.ice_fraction_xinan;
+        *dest = (void*)&cfe_ptr->soil_reservoir.ice_fraction_xinanjiang;
         return BMI_SUCCESS;
     }
 
@@ -2271,7 +2271,7 @@ static int Get_state_var_ptrs (Bmi *self, void *ptr_list[])
     ptr_list[12] = &(state->soil_reservoir.coeff_secondary );      
     ptr_list[13] = &(state->soil_reservoir.exponent_secondary );
     ptr_list[14] = &(state->soil_reservoir.ice_fraction_schaake);
-    ptr_list[15] = &(state->soil_reservoir.ice_fraction_xinan);
+    ptr_list[15] = &(state->soil_reservoir.ice_fraction_xinanjiang);
     //------------------------------
     // Vars in gw reservoir struct
     //------------------------------ 
@@ -3103,7 +3103,7 @@ extern void print_cfe_flux_at_timestep(cfe_state_struct* cfe_ptr){
 	                   *cfe_ptr->flux_Qout_m*1000.0,
 	                   cfe_ptr->soil_reservoir.storage_m*1000.0,
 	                   cfe_ptr->soil_reservoir.ice_fraction_schaake*1000.0,
-	                   cfe_ptr->soil_reservoir.ice_fraction_xinan);
+	                   cfe_ptr->soil_reservoir.ice_fraction_xinanjiang);
 }
 
 extern void mass_balance_check(cfe_state_struct* cfe_ptr){

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -122,12 +122,12 @@ extern void cfe(
 
 	// to ensure that ice_fraction_xinan is set to 0.0 for uncoupled SFT
 	if(!soil_reservoir_struct->is_sft_coupled)
-	  soil_reservoir_struct->ice_fraction_xinan = 0.0;
+	  soil_reservoir_struct->ice_fraction_xinanjiang = 0.0;
 	
 	Xinanjiang_partitioning_scheme(timestep_rainfall_input_m, soil_reservoir_struct->storage_threshold_primary_m,
 				       soil_reservoir_struct->storage_max_m, soil_reservoir_struct->storage_m,
 				       &direct_runoff_params_struct, &direct_output_runoff_m, &infiltration_depth_m,
-				       soil_reservoir_struct->ice_fraction_xinan);
+				       soil_reservoir_struct->ice_fraction_xinanjiang);
       }
     else
       {
@@ -453,7 +453,7 @@ void Xinanjiang_partitioning_scheme(double water_input_depth_m, double field_cap
                                     double max_soil_moisture_storage_m, double column_total_soil_water_m,
                                     struct direct_runoff_parameters_structure *parms,
 				    double *surface_runoff_depth_m, double *infiltration_depth_m,
-				    double ice_fraction_xinan)
+				    double ice_fraction_xinanjiang)
 {
   //------------------------------------------------------------------------
   //  This module takes the water_input_depth_m and separates it into surface_runoff_depth_m
@@ -483,7 +483,7 @@ void Xinanjiang_partitioning_scheme(double water_input_depth_m, double field_cap
   //   double  b_shape_parameter             b parameter
   //   double  x_shape_parameter             x parameter
   //   double  urban_decimal_fraction        fraction of land cover in the modeled area that is classified as urban [unitless decimal]
-  //   double  ice_fraction_xinan            fraction of top soil layer that is frozen [unitless decimal]
+  //   double  ice_fraction_xinanjiang       fraction of top soil layer that is frozen [unitless decimal]
   //
   // Outputs
   //   double  surface_runoff_depth_m        amount of water partitioned to surface water this time step [m]
@@ -522,7 +522,7 @@ void Xinanjiang_partitioning_scheme(double water_input_depth_m, double field_cap
       // estimate the fraction of the modeled area that is impervious (impervious_fraction) based on 
 	   // urban classification (hard coded 95% [0.95] impervious) and frozen soils (passed to cfe 
       // from freeze-thaw model) using a weighted average. 
-      impervious_fraction = (parms->urban_decimal_fraction * 0.95) + ((1 - parms->urban_decimal_fraction) * ice_fraction_xinan);
+      impervious_fraction = (parms->urban_decimal_fraction * 0.95) + ((1 - parms->urban_decimal_fraction) * ice_fraction_xinanjiang);
   
     // Calculate the impervious runoff (see eq. 309 from Knoben et al).
     impervious_runoff_m = impervious_fraction * water_input_depth_m;


### PR DESCRIPTION
The PR changes bmi input variable name from `ice_fraction_xinan` to `ice_fraction_xinanjiang` to make it more descriptive and consistent with SoilFreezeThaw output name.

## Additions
- None

## Removals
- None

## Changes
- BMI input variable name change

## Testing
1. All existing tests pass (include pseudo and nextgen tests)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: