### PR TITLE
Fix allocation size for runoff_queue_m_per_timestep

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1286,7 +1286,7 @@ static int Initialize (Bmi *self, const char *file)
     init_soil_reservoir(cfe_bmi_data_ptr);
 
     // Initialize the runoff queue to empty to start with
-    cfe_bmi_data_ptr->runoff_queue_m_per_timestep = malloc(sizeof(double) * cfe_bmi_data_ptr->num_giuh_ordinates + 1);
+    cfe_bmi_data_ptr->runoff_queue_m_per_timestep = malloc(sizeof(double) * (cfe_bmi_data_ptr->num_giuh_ordinates + 1));
     for (i = 0; i < cfe_bmi_data_ptr->num_giuh_ordinates + 1; i++)
         cfe_bmi_data_ptr->runoff_queue_m_per_timestep[i] = 0.0;
 


### PR DESCRIPTION
Affected line is allocating `(sizeof(double) * num_giuh_ordinates) + 1` bytes instead of `sizeof(double) * (num_giuh_ordinates + 1)` bytes, causing a heap buffer overflow in the following loop.

i.e. https://github.com/NOAA-OWP/ngen/actions/runs/7388585995/job/20099716766?pr=694

## Changes

- Adds parenthesis around `num_giuh_ordinates + 1`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: