### PR TITLE
Remove re-checkout

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -5,9 +5,9 @@ name: Ngen Integration Tests
 # Controls when the action will run.
 on:
   push:
-    branches: [ main, dev, notreal ]
+    branches: [ master, dev, notreal ]
   pull_request:
-    branches: [ main, dev, notreal ]
+    branches: [ master, dev, notreal ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -1,4 +1,4 @@
-# Test ngen-smp integration
+# Test ngen-cfe integration
 
 name: Ngen Integration Tests
 
@@ -20,7 +20,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Run general unit tests in linux environment
-  test_smp:
+  test_cfe:
     # The type of runner that the job will run on
     strategy:
       matrix:

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build the CFE Library
         run: |
-          cmake -B cmake_build -S .
+          cmake -B cmake_build -S . -DNGEN=ON
           make -C cmake_build
 
       - name: Save CFE to a Temp Directory

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -81,7 +81,7 @@ jobs:
           rm -rf extern/cfe/cfe/*
           mv ${{runner.temp}}/cfe/* extern/cfe/cfe
 
-      - name: Run Ngen Test for CFE
+      - name: Run Ngen Test for CFE Couple with PET
         run: |
           mv ${{ steps.ngen_id1.outputs.build-dir }} ./ngen-build/
           inputfile='extern/cfe/cfe/realizations/realization_cfe_pet_ngenCI.json'

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -1,13 +1,13 @@
-# Test ngen-cfe integration
+# Test ngen-smp integration
 
 name: Ngen Integration Tests
 
 # Controls when the action will run.
 on:
   push:
-    branches: [ master, dev, notreal ]
+    branches: [ main, dev, notreal ]
   pull_request:
-    branches: [ master, dev, notreal ]
+    branches: [ main, dev, notreal ]
   workflow_dispatch:
 
 env:
@@ -20,7 +20,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # Run general unit tests in linux environment
-  test_surfacebmi_plus_cfe:
+  test_smp:
     # The type of runner that the job will run on
     strategy:
       matrix:
@@ -30,13 +30,27 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # Checkout and build the CFE
+      - name: Checkout the commit
+        uses: actions/checkout@v4
+
+      - name: Build the CFE Library
+        run: |
+          cmake -B cmake_build -S .
+          make -C cmake_build
+
+      - name: Save CFE to a Temp Directory
+        run: |
+          # Move files to a temporary directory
+          mkdir ${{runner.temp}}/cfe
+          mv ./* ${{runner.temp}}/cfe
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout actions in another repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: noaa-owp/ngen
 
-      # Build some necessary submodules
       - name: Build PET
         id: submod_build_5
         uses: ./.github/actions/ngen-submod-build
@@ -62,40 +76,13 @@ jobs:
           bmi_c: 'ON'
         timeout-minutes: 15
 
-      - name: Cleanup Ngen Build
+      - name: Move CFE Files Including cmake_build to Appropriate Directory
         run: |
-          # Move ngen build artifacts to temp directory
-          mv ${{ steps.ngen_id1.outputs.build-dir }} ${{runner.temp}}/ngen-build/
-          mv .github ${{runner.temp}}/.github
-          mv extern ${{runner.temp}}/extern
-          mv data ${{runner.temp}}/data
+          rm -rf extern/cfe/cfe/*
+          mv ${{runner.temp}}/cfe/* extern/cfe/cfe
 
-      - name: Run surfacebmi plus cfebmi
+      - name: Run Ngen Test for CFE
         run: |
-          echo "end of ngen_integration testing"
-
-      # Checkout and build CFE
-      - name: Checkout the commit
-        uses: actions/checkout@v4
-
-      - name: Build CFE Library for Ngen
-        run: |
-          cmake -B cmake_build -S . -DNGEN=ON
-          make -C cmake_build
-
-          # Move ngen build and other files to appropriate directory to run ngen
-          mv ${{runner.temp}}/ngen-build ./ngen-build
-          mv ${{runner.temp}}/extern/sloth extern
-          cp -r ${{runner.temp}}/extern/evapotranspiration extern
-          mv ${{runner.temp}}/data data
-
-          # Run ngen with CFE with PET
-          inputfile='realizations/realization_cfe_pet_ngenCI.json'
+          mv ${{ steps.ngen_id1.outputs.build-dir }} ./ngen-build/
+          inputfile='extern/cfe/cfe/realizations/realization_cfe_pet_ngenCI.json'
           ./ngen-build/ngen ./data/catchment_data.geojson "cat-27" ./data/nexus_data.geojson "nex-26" $inputfile
-
-      # The following remove a post ngen build error likely related to the temporary files left over during the
-      # build process
-      - name: Re-checkout Ngen
-        uses: actions/checkout@v3
-        with:
-          repository: noaa-owp/ngen

--- a/realizations/realization_cfe_pet_ngenCI.json
+++ b/realizations/realization_cfe_pet_ngenCI.json
@@ -32,7 +32,7 @@
                                 "model_type_name": "bmi_c_pet",
                                 "library_file": "./extern/evapotranspiration/evapotranspiration/cmake_build/libpetbmi",
                                 "forcing_file": "",
-                                "init_config": "./configs/cat_87_bmi_config_pet_pass.txt",
+                                "init_config": "./extern/cfe/cfe/configs/cat_87_bmi_config_pet_pass.txt",
                                 "allow_exceed_end_time": true,
                                 "main_output_variable": "water_potential_evaporation_flux",
                                 "registration_function":"register_bmi_pet",
@@ -43,9 +43,9 @@
                             "name": "bmi_c",
                             "params": {
                                 "model_type_name": "bmi_c_cfe",
-                                "library_file": "./cmake_build/libcfebmi",
+                                "library_file": "./extern/cfe/cfe/cmake_build/libcfebmi",
                                 "forcing_file": "",
-                                "init_config": "./configs/cat_87_bmi_config_cfe_pass.txt",
+                                "init_config": "./extern/cfe/cfe/configs/cat_87_bmi_config_cfe_pass.txt",
                                 "allow_exceed_end_time": true,
                                 "main_output_variable": "Q_OUT",
                                 "registration_function": "register_bmi_cfe",
@@ -72,7 +72,7 @@
             }
         ],
         "forcing": {
-	    "path" : "./forcings/cat87_01Dec2015-.csv"
+	    "path" : "./extern/cfe/cfe/forcings/cat87_01Dec2015-.csv"
         }
     },
     "time": {


### PR DESCRIPTION
This PR removes the re-checkout block of codes in the original `ngen_integration.yaml` so the code is cleaner. Also, the CFE shared library build is updated to be consistent with CFE update.

## Additions

-

## Removals

-

## Changes

.github/workflows/ngen_integration.yaml
realizations/realization_cfe_pet_ngenCI.json

## Testing

Passed all automated tests.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] ~~Visually tested in supported browsers and devices (see checklist below :point_down:)~~
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] macOS
