### PR TITLE
Implement standard definitions of `Set_value` & `Set_value_at_indices`

### DIFF
--- a/configs/laramie_bmi_config_cfe_pass_aet_rz.txt
+++ b/configs/laramie_bmi_config_cfe_pass_aet_rz.txt
@@ -26,6 +26,6 @@ surface_partitioning_scheme=Schaake
 #b_Xinanjiang_shape_parameter=1
 #x_Xinanjiang_shape_parameter=1
 #urban_decimal_fraction=0.0
-aet_rootzone=true
+is_aet_rootzone=true
 soil_layer_depths=0.1,0.4,1.0,2.0
 max_rootzone_layer=2

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2031,6 +2031,7 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     return BMI_SUCCESS;
 }*/
 
+// JG: 02.05.2024 - Implimenting "standard" BMI definition 
 {
     void * to = NULL;
     int itemsize = 0;
@@ -2066,7 +2067,9 @@ static int Set_value (Bmi *self, const char *name, void *array)
     return Set_value_at_indices(self, name, inds, 1, array);*/
     
     
-  // This is the sample code from read the docs
+  	// This is the sample code from read the docs
+	
+	// JG: 02.05.2024 - Implimenting "standard" BMI definition 
     void * dest = NULL;
     int nbytes = 0;
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2031,7 +2031,7 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
     return BMI_SUCCESS;
 }*/
 
-// JG: 02.05.2024 - Implimenting "standard" BMI definition 
+// JG: 02.05.2024 - Implementing "standard" BMI definition 
 {
     void * to = NULL;
     int itemsize = 0;
@@ -2068,8 +2068,7 @@ static int Set_value (Bmi *self, const char *name, void *array)
     
     
   	// This is the sample code from read the docs
-	
-	// JG: 02.05.2024 - Implimenting "standard" BMI definition 
+	// JG: 02.05.2024 - Implementing "standard" BMI definition 
     void * dest = NULL;
     int nbytes = 0;
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -731,7 +731,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
         }
 
         /*-------------------- Root zone AET development -rlm -----------------------*/
-	if (strcmp(param_key, "aet_rootzone") == 0) {
+	if (strcmp(param_key, "is_aet_rootzone") == 0) {
 
 	  if ( strcmp(param_value, "true")==0 || strcmp(param_value, "True")==0 || strcmp(param_value,"1")==0)
 	    is_aet_rootzone_set = TRUE;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1963,7 +1963,7 @@ static int Get_value (Bmi *self, const char *name, void *dest)
 
 
 static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int len, void *src)
-{
+/*{
     if (len < 1)
         return BMI_FAILURE;
     
@@ -2029,22 +2029,44 @@ static int Set_value_at_indices (Bmi *self, const char *name, int * inds, int le
      }   
         
     return BMI_SUCCESS;
+}*/
+
+{
+    void * to = NULL;
+    int itemsize = 0;
+
+    if (self->get_value_ptr (self, name, &to) == BMI_FAILURE)
+        return BMI_FAILURE;
+
+    if (self->get_var_itemsize(self, name, &itemsize) == BMI_FAILURE)
+        return BMI_FAILURE;
+
+    { /* Copy the data */
+        size_t i;
+        size_t offset;
+        char * ptr;
+        for (i=0, ptr=(char*)src; i<len; i++, ptr+=itemsize) {
+            offset = inds[i] * itemsize;
+            memcpy ((char*)to + offset, ptr, itemsize);
+        }
+    }
+    return BMI_SUCCESS;
 }
 
 
 static int Set_value (Bmi *self, const char *name, void *array)
 {
-    // Avoid using set value, call instead set_value_at_index
+/*    // Avoid using set value, call instead set_value_at_index
     // Use nested call to "by index" version
 
     // Here, for now at least, we know all the variables are scalar, so
     int inds[] = {0};
 
     // Then we can just ...
-    return Set_value_at_indices(self, name, inds, 1, array);
+    return Set_value_at_indices(self, name, inds, 1, array);*/
     
     
-/*  This is the sample code from read the docs
+  // This is the sample code from read the docs
     void * dest = NULL;
     int nbytes = 0;
 
@@ -2057,7 +2079,7 @@ static int Set_value (Bmi *self, const char *name, void *array)
     memcpy (dest, array, nbytes);
 
     return BMI_SUCCESS;
-*/    
+    
 }
 
 


### PR DESCRIPTION
Adjusts two BMI functions,
1. `Set_value()`
2. `Set_value_at_indices()`

to "standard" BMI definitions according to examples and readme documents 

3. Also - minor `is_aet_rootzone` (boolean flag) name updates left over from PR #105

## Changes

- bmi_c.c

## Testing

1. NextGen Integration [Workflow](https://github.com/NOAA-OWP/cfe/blob/master/.github/workflows/ngen_integration.yaml) in parent repo passes; this checks `ngen` build/run coupling cfe & pet
2. Standalone and BMI unit testing workflow (yml [here](https://github.com/NOAA-OWP/cfe/blob/master/.github/workflows/Build_and_Run_Standalone_Test.yml))
3. NextGen [Realization](https://github.com/NOAA-OWP/SoilFreezeThaw/blob/master/realizations/realization_coupled.json) in `SoilFreezeThaw`; coupling cfe, sft, smp & pet
4. Config sets both `is_sft_coupled` & `is_aet_rootzone` to `true`. e.g.,
```
is_sft_coupled=true
ice_content_threshold=0.15
is_aet_rootzone=true
soil_layer_depths=0.1,0.4,1.0,2.0
max_rootzone_layer=2
```
as outlined in configs/readme [here](https://github.com/NOAA-OWP/cfe/blob/master/configs/README.md#cfe-coupled-to-soil-freeze-thaw-model-sft) & [here](https://github.com/NOAA-OWP/cfe/blob/master/configs/README.md#rootzone-based-actual-evapotranspiration-aet).


## Notes

- Closes Issue #93 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x] Linux
- [x] Browser
