### PR TITLE
Support building with `-Werror` for ngen

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -510,7 +510,8 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
 
     for (i = 0; i < config_line_count; i++) {
         char *param_key, *param_value, *param_units;
-        fgets(config_line, max_config_line_length + 1, fp);
+        if (fgets(config_line, max_config_line_length + 1, fp) == NULL)
+            return BMI_FAILURE;
 #if CFE_DEBUG >= 3
         printf("Line value: ['%s']\n", config_line);
 #endif
@@ -1252,12 +1253,14 @@ static int Initialize (Bmi *self, const char *file)
         long year, month, day, hour, minute;
         double dsec;
         // First read the header line
-        fgets(line_str, max_forcing_line_length + 1, ffp);
+        if (fgets(line_str, max_forcing_line_length + 1, ffp) == NULL)
+            return BMI_FAILURE;
         
         aorc_forcing_data_cfe forcings;
 
         for (i = 0; i < cfe_bmi_data_ptr->num_timesteps; i++) {
-            fgets(line_str, max_forcing_line_length + 1, ffp);  // read in a line of AORC data.
+            if (fgets(line_str, max_forcing_line_length + 1, ffp) == NULL)  // read in a line of AORC data.
+                return BMI_FAILURE;
             parse_aorc_line_cfe(line_str, &year, &month, &day, &hour, &minute, &dsec, &forcings);
     #if CFE_DEBUG > 0
             printf("Forcing data: [%s]\n", line_str);


### PR DESCRIPTION
In support of NOAA-OWP/ngen#718, CFE needs to build without warnings in that setting.

## Changes

- Check the return values of the few `fgets()` calls in input reading.

## Testing

1. Local build no longer warns
2. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] macOS
