### PR TITLE
Tighten CI checks

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build the CFE Library
         run: |
-          cmake -B cmake_build -S . -DNGEN=ON
+          cmake -B cmake_build -S . -DNGEN=ON -DCMAKE_C_FLAGS='-g -Og -fsanitize=address -Werror'
           make -C cmake_build
 
       - name: Save CFE to a Temp Directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,6 @@ set(Red         "${Esc}[32m")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_C_COMPILER $ENV{CC})
-set(CMAKE_CXX_COMPILER $ENV{CXX})
-
 # module setup options
 
 option(BASE "BASE" OFF)
@@ -46,7 +43,6 @@ endif()
 # set the project name
 project(cfebmi VERSION 1.0.0 DESCRIPTION "OWP CFE BMI Module Shared Library")
 
-set(CMAKE_BUILD_TYPE Debug)
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
     message("Debug build.")
 ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -54,9 +50,6 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 message(CMAKE_CXX_COMPILER " ${CMAKE_CXX_COMPILER}")
 message(CMAKE_C_COMPILER " ${CMAKE_C_COMPILER}")
 message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
-
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 
 # add the executable
 


### PR DESCRIPTION
We want to ensure code quality issues get caught relatively early, before they cause problems in ngen integration tests on updates.

## Changes

- Enable AddressSanitizer (ASan)
- Build with `-Werror` (including `-Og` to get control/data-flow analysis for necessary warnings)
- Stop smashing CMake options that the user may have set on the command line

## Testing

1. CI

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] macOS
