### PR TITLE
add aetrootzone option to workflow

### DIFF
--- a/.github/workflows/Build_and_Run_Standalone_Test.yml
+++ b/.github/workflows/Build_and_Run_Standalone_Test.yml
@@ -57,6 +57,15 @@ jobs:
         make
         cd ..
         ./run_cfe.sh FORCINGPET
+        
+    - name : Build and Run AETROOTZONE option
+      run: |
+        git clone https://github.com/NOAA-OWP/SoilMoistureProfiles extern/SoilMoistureProfiles
+        cd build
+        cmake ../ -DAETROOTZONE=ON
+        make
+        cd ..
+        ./run_cfe.sh AETROOTZONE
 
     - name: Build and Run BMI Unit Test
       run: |


### PR DESCRIPTION
Includes 4th pseudo-framework option (`AETROOTZONE`) to standalone workflow test.  Closes issue #109. 