### PR TITLE
backwards_compibility_changes

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -27,7 +27,7 @@ Example configuration files are provided in this directory. To build and run the
 | num_timesteps  | *int* |   |  | time_info |  | set to `1` if `forcing_file=BMI`   |
 | verbosity | *int* | `0`-`3`  |   | option |   |  prints various debug and bmi info  |
 | surface_partitioning_scheme | *char* | `Xinanjiang` or `Schaake`  |  | parameter_adjustable | direct runoff |    |
-| surface_runoff_scheme | *char* | GIUH or NASH_CASCADE | | parameter_adjustable | surface runoff | also supports 1 for GIUH and 2 for NASH_CASCADE |
+| surface_runoff_scheme | *char* | GIUH or NASH_CASCADE | | parameter_adjustable | surface runoff | also supports 1 for GIUH and 2 for NASH_CASCADE; default is GIUH |
 | N_nash_surface | *int* |   |   | parameter_adjustable | surface runoff | number of Nash reservoirs for surface runoff   |
 | K_nash_surface | *double* |   | 1/meters [m^-1]  | parameter_adjustable | surface runoff | Nash Config param for surface runoff   |
 | nash_storage_surface | *double* |   | meters [m]  | parameter_adjustable | surface runoff | Nash Config param; reservoir surface storage; default is zero storage |
@@ -56,7 +56,7 @@ If the **Xinanjiang** scheme is choosen, four parameters need to be included in 
 ## Surface runoff options in CFE
 The user has the option to pick a particular surface runoff (aka surface runoff scheme) method:
 
-1. GIUH-based surface runoff (configuration: `surface_runoff_scheme=GIUH`)
+1. GIUH-based surface runoff (configuration: `surface_runoff_scheme=GIUH`). This is the default option.
 2. Nash_Cascade-based surface runoff (configuration: `surface_runoff_scheme=NASH_CASCADE`). In this method, GIUH is used to derive Nash cascade parameters K and N.
 
 

--- a/configs/cat_87_bmi_config_cfe.txt
+++ b/configs/cat_87_bmi_config_cfe.txt
@@ -20,7 +20,6 @@ nash_storage=0.0,0.0
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 num_timesteps=1
 verbosity=2
-surface_runoff_scheme=GIUH
 surface_partitioning_scheme=Xinanjiang
 a_Xinanjiang_inflection_point_parameter=1
 b_Xinanjiang_shape_parameter=1

--- a/configs/cat_87_bmi_config_cfe_pass.txt
+++ b/configs/cat_87_bmi_config_cfe_pass.txt
@@ -20,7 +20,6 @@ nash_storage=0.0,0.0
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 num_timesteps=1
 verbosity=1
-surface_runoff_scheme=GIUH
 surface_partitioning_scheme=Xinanjiang
 a_Xinanjiang_inflection_point_parameter=1
 b_Xinanjiang_shape_parameter=1

--- a/configs/cat_87_config_cfe_pass_surfnash.txt
+++ b/configs/cat_87_config_cfe_pass_surfnash.txt
@@ -22,7 +22,6 @@ N_nash_surface=2
 K_nash_surface=0.83089
 nsubsteps_nash_surface=12
 nash_storage_surface=0.0,0.0
-#giuh_ordinates=0.2,0.3,0.2,0.15,0.1,0.05
 num_timesteps=1
 verbosity=1
 surface_partitioning_scheme=Xinanjiang

--- a/configs/cat_89_bmi_config_cfe_unit_test.txt
+++ b/configs/cat_89_bmi_config_cfe_unit_test.txt
@@ -20,5 +20,4 @@ nash_storage=0.0,0.0
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 num_timesteps=1
 verbosity=2
-surface_runoff_scheme=GIUH
 surface_partitioning_scheme=Schaake

--- a/configs/laramie_bmi_config_cfe_pass_aet_rz.txt
+++ b/configs/laramie_bmi_config_cfe_pass_aet_rz.txt
@@ -20,7 +20,6 @@ nash_storage=0.0,0.0
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 num_timesteps=1
 verbosity=1
-surface_runoff_scheme=GIUH
 surface_partitioning_scheme=Schaake
 #surface_partitioning_scheme=Xinanjiang
 #a_Xinanjiang_inflection_point_parameter=1

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -13,7 +13,7 @@
 #define CFE_DEBUG 1
 
 #define INPUT_VAR_NAME_COUNT 5
-#define OUTPUT_VAR_NAME_COUNT 13
+#define OUTPUT_VAR_NAME_COUNT 14
 
 #define STATE_VAR_NAME_COUNT 94   // must match var_info array size
 
@@ -181,7 +181,8 @@ int j = 0;
 static const char *output_var_names[OUTPUT_VAR_NAME_COUNT] = {
         "RAIN_RATE",
         "DIRECT_RUNOFF",
-        "SURFACE_RUNOFF",
+        "GIUH_RUNOFF",
+	"NASH_RUNOFF",
         "NASH_LATERAL_RUNOFF",
         "DEEP_GW_TO_CHANNEL_FLUX",
 	"SOIL_TO_GW_FLUX",
@@ -207,6 +208,7 @@ static const char *output_var_types[OUTPUT_VAR_NAME_COUNT] = {
         "double",
       	"double",
 	"double",
+	"double",
 	"int"
 };
 
@@ -223,6 +225,7 @@ static const int output_var_item_count[OUTPUT_VAR_NAME_COUNT] = {
         1,
         1,
         1,
+	1,
 	1
 };
 
@@ -238,6 +241,7 @@ static const char *output_var_units[OUTPUT_VAR_NAME_COUNT] = {
         "m",
         "m",
       	"m",
+	"m",
 	"m",
 	"none"
 };
@@ -255,6 +259,7 @@ static const int output_var_grids[OUTPUT_VAR_NAME_COUNT] = {
         0,
         0,
         0,
+	0,
 	0
 };
 
@@ -271,7 +276,8 @@ static const char *output_var_locations[OUTPUT_VAR_NAME_COUNT] = {
         "node",
         "node",
         "node",
-	"node"
+	"node",
+	"none"
 };
 
 // Don't forget to update Get_value/Get_value_at_indices (and setter) implementation if these are adjusted
@@ -1016,10 +1022,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
 
     /*------------------- surface runoff scheme -AJK----------------------------- */
     if(is_surface_runoff_scheme_set == FALSE) {
-#if CFE_DEBUG >= 1
-      printf("Config param 'surface_runoff_scheme' not found in config file\n");
-#endif
-      return BMI_FAILURE;
+      model->surface_runoff_scheme = GIUH;
     }
 
     // Used for parsing strings representing arrays of values below
@@ -1930,7 +1933,7 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
-    if (strcmp (name, "SURFACE_RUNOFF") == 0) {
+    if (strcmp (name, "GIUH_RUNOFF") == 0 || strcmp (name, "NASH_RUNOFF") == 0) {
         *dest = (void *) ((cfe_state_struct *)(self->data))->flux_surface_runoff_m;
         return BMI_SUCCESS;
     }


### PR DESCRIPTION
The PR addresses backward compatibility issue related to config file parameter `surface_runoff_scheme` that arose in the PR #112. The default option for surface_runoff_scheme is set to `GIUH`. Reverted config files and added a new BMI variable NASH_RUNOFF.  Note: this PR is not to be mixed with PR #116. 

## Additions
- Added a new BMI variable NASH_RUNOFF

## Removals
- None

## Changes
- No changes to the functionality

## Testing
1. All tests results are consistent with pre-changes results


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: