### PR TITLE
Added retention_depth to calibrated params

### DIFF
--- a/realizations/realization_cfe_pet_surfnash.json
+++ b/realizations/realization_cfe_pet_surfnash.json
@@ -76,7 +76,8 @@
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
 				"model_params": {
-				    "Kinf_nash_surface": 0.04
+				    "Kinf_nash_surface": 0.04,
+				    "retention_depth_nash_surface": 0.1043
 				},
                                 "uses_forcing_file": false
                             }

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -25,7 +25,7 @@
 #define STATE_VAR_NAME_COUNT 94   // must match var_info array size
 
 
-#define PARAM_VAR_NAME_COUNT 18
+#define PARAM_VAR_NAME_COUNT 19
 // NOTE: If you update the params, also update the unit test in ../test/main_unit_test_bmi.c
 static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
     "maxsmc", "satdk", "slope", "b", "Klf",
@@ -33,6 +33,7 @@ static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
     "satpsi","wltsmc","alpha_fc","refkdt",
     "a_Xinanjiang_inflection_point_parameter","b_Xinanjiang_shape_parameter","x_Xinanjiang_shape_parameter",
     "Kinf_nash_surface",
+    "retention_depth_nash_surface",
     "N_nash_subsurface"
 };
 
@@ -41,7 +42,7 @@ static const char *param_var_types[PARAM_VAR_NAME_COUNT] = {
     "double", "double", "double", "double",
     "double", "double", "double", "double",
     "double","double","double", "double",
-    "int"
+    "double", "int"
 };
 //----------------------------------------------
 // Put variable info into a struct to simplify
@@ -1931,6 +1932,12 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
+    if (strcmp(name, "retention_depth_nash_surface") == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->nash_surface_params.retention_depth;
+        return BMI_SUCCESS;
+    }
     /***********************************************************/
     /***********    OUTPUT   ***********************************/
     /***********************************************************/

--- a/test/main_unit_test.c
+++ b/test/main_unit_test.c
@@ -393,7 +393,7 @@ main(int argc, const char *argv[]){
   printf("\nTEST BMI MODEL PARAMETERS\n*************************\n");
   
   //Set number of params -- UPDATE if params changed
-#define PARAM_COUNT 18
+#define PARAM_COUNT 19
   
   // expected_param_names copied directly from param_var_names[PARAM_VAR_NAME_COUNT] in ../src/bmi_cfe.c
   static const char *expected_param_names[PARAM_COUNT] = {
@@ -401,8 +401,9 @@ main(int argc, const char *argv[]){
     "Kn", "Cgw", "expon", "max_gw_storage",
     "satpsi","wltsmc","alpha_fc","refkdt",
     "a_Xinanjiang_inflection_point_parameter","b_Xinanjiang_shape_parameter","x_Xinanjiang_shape_parameter",
-    "Kinf_nash_surface",
+    "Kinf_nash_surface", "retention_depth_nash_surface",
     "N_nash_subsurface"};
+  
   double test_set_value = 4.2;
   double test_get_value = 0.0;
   int    test_set_value_int = 5;


### PR DESCRIPTION
The PR adds a new parameter `retention_depth_surface_nash` to the calibratable parameters list per Fred's request.

## Additions
- added a calibratable parameter

## Removals
- None

## Changes
- None

## Testing
1. All existing tests passed


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: