### PR TITLE
removed N_nash_subsruface bmi parameter

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,5 +1,5 @@
 ## Configuration File
-Example configuration files are provided in this directory. To build and run the given examples see the instructions [here](https://github.com/NOAA-OWP/cfe/blob/master/INSTALL.md). A detailed description of the parameters for model configuration (i.e., initialize/setup) is provided below. The asterisk (*) denotes calibratable parameters.
+Example configuration files are provided in this directory. To build and run the given examples see the instructions [here](https://github.com/NOAA-OWP/cfe/blob/master/INSTALL.md). A detailed description of the parameters for model configuration (i.e., initialize/setup) is provided below. The asterisk (*) denotes calibratable parameters. The has (#) shows the parameters only used with the Nash Cascade-based runoff.
 
 | Variable | Datatype |  Limits  | Units | Role | Process | Description |
 | -------- | -------- | ------ | ----- | ---- | ------- | ----------- |
@@ -28,12 +28,12 @@ Example configuration files are provided in this directory. To build and run the
 | verbosity | *int* | `0`-`3`  |   | optional |   |  prints various debug and bmi info (defaults to 0) |
 | surface_water_partitioning_scheme | *char* | `Xinanjiang` or `Schaake`  |  | parameter_adjustable | infiltraton excess |    |
 | surface_runoff_scheme | *char* | GIUH or NASH_CASCADE | | parameter_adjustable | surface runoff | also supports 1 for GIUH and 2 for NASH_CASCADE; default is GIUH |
-| N_nash_surface | *int* |   |   | parameter_adjustable | surface runoff | number of Nash reservoirs for surface runoff   |
-| K_nash_surface | *double* |   | 1/hour [h^-1]  | parameter_adjustable | surface runoff | Nash Config param for surface runoff   |
-| nash_storage_surface | 1D array (*double*) |   | meters [m]  | parameter_adjustable | surface runoff | Nash Config param; reservoir surface storage; default is zero storage |
-| nsubsteps_nash_surface | *int* |   |   | parameter_adjustable | surface runoff | optional (default = 10); number of subtimstep for Nash runoff |
-| Kinf_nash_surface | *double* |   | 1/hour [h^-1] | parameter_adjustable | surface runoff | optional (default = 0.05); storage fraction per hour that moves from reservoirs to soil |
-| retention_depth_nash_surface | *double* |   | m | parameter_adjustable | surface runoff | optional (default = 0.001); water retention depth threshold (only applied to the first reservoir) |
+| #N_nash_surface | *int* |   |   | parameter_adjustable | surface runoff | number of Nash reservoirs for surface runoff   |
+| #K_nash_surface | *double* |   | 1/hour [h^-1]  | parameter_adjustable | surface runoff | Nash Config param for surface runoff   |
+| #nash_storage_surface | 1D array (*double*) |   | meters [m]  | parameter_adjustable | surface runoff | Nash Config param; reservoir surface storage; default is zero storage |
+| #nsubsteps_nash_surface | *int* |   |   | parameter_adjustable | surface runoff | optional (default = 10); number of subtimstep for Nash runoff |
+| #*Kinf_nash_surface | *double* |   | 1/hour [h^-1] | parameter_adjustable | surface runoff | optional (default = 0.05); storage fraction per hour that moves from reservoirs to soil |
+| #*retention_depth_nash_surface | *double* |   | m | parameter_adjustable | surface runoff | optional (default = 0.001); water retention depth threshold (only applied to the first reservoir) |
 | *a_Xinanjiang_inflection_point_parameter | *double* |   |  | parameter_adjustable | infiltration excess runoff | when `surface_water_partitioning_scheme=Xinanjiang`   |
 | *b_Xinanjiang_shape_parameter=1  | *double* |   |   | parameter_adjustable  | infiltration excess runoff | when `surface_water_partitioning_scheme=Xinanjiang`   |
 | *x_Xinanjiang_shape_parameter=1  | *double* |   |   | parameter_adjustable | infiltration excess runoff | when `surface_water_partitioning_scheme=Xinanjiang`   |

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -25,7 +25,7 @@
 #define STATE_VAR_NAME_COUNT 94   // must match var_info array size
 
 
-#define PARAM_VAR_NAME_COUNT 19
+#define PARAM_VAR_NAME_COUNT 18
 // NOTE: If you update the params, also update the unit test in ../test/main_unit_test_bmi.c
 static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
     "maxsmc", "satdk", "slope", "b", "Klf",
@@ -33,8 +33,7 @@ static const char *param_var_names[PARAM_VAR_NAME_COUNT] = {
     "satpsi","wltsmc","alpha_fc","refkdt",
     "a_Xinanjiang_inflection_point_parameter","b_Xinanjiang_shape_parameter","x_Xinanjiang_shape_parameter",
     "Kinf_nash_surface",
-    "retention_depth_nash_surface",
-    "N_nash_subsurface"
+    "retention_depth_nash_surface"
 };
 
 static const char *param_var_types[PARAM_VAR_NAME_COUNT] = {
@@ -42,7 +41,7 @@ static const char *param_var_types[PARAM_VAR_NAME_COUNT] = {
     "double", "double", "double", "double",
     "double", "double", "double", "double",
     "double","double","double", "double",
-    "double", "int"
+    "double"
 };
 //----------------------------------------------
 // Put variable info into a struct to simplify
@@ -1956,13 +1955,6 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
         return BMI_SUCCESS;
     }
 
-    if (strcmp (name, "N_nash_subsurface") == 0) {
-        cfe_state_struct *cfe_ptr;
-        cfe_ptr = (cfe_state_struct *) self->data;
-        *dest = (void*)&cfe_ptr->N_nash_subsurface;
-        return BMI_SUCCESS;
-    }
-
     if (strcmp (name, "Kinf_nash_surface") == 0) {
         cfe_state_struct *cfe_ptr;
         cfe_ptr = (cfe_state_struct *) self->data;
@@ -2197,20 +2189,6 @@ static int Set_value (Bmi *self, const char *name, void *src)
         cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
         cfe_ptr->infiltration_excess_params_struct.Schaake_adjusted_magic_constant_by_soil_type = cfe_ptr->NWM_soil_params.refkdt * cfe_ptr->NWM_soil_params.satdk / 0.000002;
 
-    }
-
-    if (strcmp (name, "N_nash_subsurface") == 0) {
-        cfe_state_struct* cfe_ptr = (cfe_state_struct *) self->data;
-
-	if( cfe_ptr->nash_storage_subsurface != NULL )
-	  free(cfe_ptr->nash_storage_subsurface);
-        cfe_ptr->nash_storage_subsurface = malloc(sizeof(double) * cfe_ptr->N_nash_subsurface);
-
-	if( cfe_ptr->nash_storage_subsurface == NULL )
-	  return BMI_FAILURE;
-
-	for (j = 0; j < cfe_ptr->N_nash_subsurface; j++)
-	  cfe_ptr->nash_storage_subsurface[j] = 0.0;
     }
 
     if (strcmp (name, "storage_max_m") == 0) {


### PR DESCRIPTION
The PR removed the bmi parameter `N_nash_subsurface` from the list of calibratable parameters as we don't calibrate it.

## Additions
- None

## Removals
- remove `N_nash_subsurface`

## Testing

1. All existing tests passed

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: