### PR TITLE
Aet rootzone name fix

### DIFF
--- a/configs/cfe1.0/cfe_config_laramie_pass_aet_rz.txt
+++ b/configs/cfe1.0/cfe_config_laramie_pass_aet_rz.txt
@@ -27,6 +27,6 @@ surface_water_partitioning_scheme=Schaake
 #b_Xinanjiang_shape_parameter=1
 #x_Xinanjiang_shape_parameter=1
 #urban_decimal_fraction=0.0
-aet_rootzone=true
+is_aet_rootzone=true
 soil_layer_depths=0.1,0.4,1.0,2.0
 max_rootzone_layer=2

--- a/configs/cfe_config_laramie_pass_aet_rz.txt
+++ b/configs/cfe_config_laramie_pass_aet_rz.txt
@@ -23,6 +23,6 @@ K_nash_surface=0.83089
 nsubsteps_nash_surface=10
 nash_storage_surface=0.0,0.0
 surface_water_partitioning_scheme=Schaake
-aet_rootzone=true
+is_aet_rootzone=true
 soil_layer_depths=0.1,0.4,1.0,2.0
 max_rootzone_layer=2

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -765,7 +765,7 @@ int read_init_config_cfe(const char* config_file, cfe_state_struct* model)
         }
 
         /*-------------------- Root zone AET development -rlm -----------------------*/
-	if (strcmp(param_key, "aet_rootzone") == 0) {
+	if (strcmp(param_key, "is_aet_rootzone") == 0) {
 
 	  if ( strcmp(param_value, "true")==0 || strcmp(param_value, "True")==0 || strcmp(param_value,"1")==0)
 	    is_aet_rootzone_set = TRUE;


### PR DESCRIPTION
VERY minor updates left over from PR #105.  `is_aet_rootzone` (boolean flag) name changed for consistency but was ever fully adopted in bmi spec & configs. 

## Changes

- `aet_rootzone` now reads `is_aet_rootzone`

## Testing

1. All workflows pass


