### PR TITLE
ci: remove duplicate event, pull_request is a subset of pull_request_…

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -3,9 +3,6 @@ name: Add to Project
 on:
   pull_request_target:
     types: [opened, reopened]
-  pull_request:
-    types:
-      - opened
   issues:
     types:
       - opened


### PR DESCRIPTION
I think only one of these two should exist for a given workflow, and pull_request_target covers PR's from within as well as external (fork) repos.  The difference being `pull_request_target` will be given access to the token, which should be carefully reviewed for permissions.

We should probably come back and review this project integration in general, I'm not sure its being used much at the moment, it is complicating the existing testing here.