### PR TITLE
build: broken reference to bmi_cfe header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ target_include_directories(cfebmi PRIVATE include)
 
 set_target_properties(cfebmi PROPERTIES VERSION ${PROJECT_VERSION})
 
-set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER ./include/bmi_cfe.hxx)
+set_target_properties(cfebmi PROPERTIES PUBLIC_HEADER ./include/bmi_cfe.h)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Fix broken reference to `include/bmi_cfe.h` (listed as `include/bmi_cfe.hxx`) in cmake list. Among other things, fixes `cmake --install .`.