### PR TITLE
fix: ensure volstart is initialized, fixes #152

### DIFF
--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3211,6 +3211,7 @@ extern void init_soil_reservoir(cfe_state_struct* cfe_ptr)
 }*/
 
 extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
+    cfe_ptr->vol_struct.volstart         = 0.0;
     cfe_ptr->vol_struct.volin            = 0;
     cfe_ptr->vol_struct.vol_runoff       = 0;
     cfe_ptr->vol_struct.vol_infilt       = 0;


### PR DESCRIPTION
See #152


## Changes

- Ensure `volstart` is initialized

## Testing

1. Local testing of mass balance mechanics

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
