### PR TITLE
Mass balance BMI protocol implemented

### DIFF
--- a/include/cfe.h
+++ b/include/cfe.h
@@ -124,6 +124,7 @@ struct massbal
     double volout              ;
     double volend              ;
     double vol_et_from_retention_depth;
+    double cummulative_vol_in; //volstart + volin
 };
 typedef struct massbal massbal;
 

--- a/include/cfe.h
+++ b/include/cfe.h
@@ -124,7 +124,7 @@ struct massbal
     double volout              ;
     double volend              ;
     double vol_et_from_retention_depth;
-    double cummulative_vol_in; //volstart + volin
+    double cumulative_vol; //volstart + volin
     double volume_in_domain; // total volume in domain at end of time step
     double leakage; // Accumulate any known leakage or other losses from the domain, e.g. deep groundwater
 };

--- a/include/cfe.h
+++ b/include/cfe.h
@@ -125,6 +125,7 @@ struct massbal
     double volend              ;
     double vol_et_from_retention_depth;
     double cummulative_vol_in; //volstart + volin
+    double volume_in_domain; // total volume in domain at end of time step
 };
 typedef struct massbal massbal;
 

--- a/include/cfe.h
+++ b/include/cfe.h
@@ -126,6 +126,7 @@ struct massbal
     double vol_et_from_retention_depth;
     double cummulative_vol_in; //volstart + volin
     double volume_in_domain; // total volume in domain at end of time step
+    double leakage; // Accumulate any known leakage or other losses from the domain, e.g. deep groundwater
 };
 typedef struct massbal massbal;
 

--- a/include/ngen_utilities.h
+++ b/include/ngen_utilities.h
@@ -1,0 +1,70 @@
+/*
+Author: Nels Frazier
+Copyright (C) 2025 Lynker
+------------------------------------------------------------------------
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+------------------------------------------------------------------------
+
+Version 0.1
+Protocol utilities for use with the ngen model engine
+*/
+#define NGEN_MASS_IN "ngen::mass_in"
+#define NGEN_MASS_OUT "ngen::mass_out"
+#define NGEN_MASS_STORED "ngen::mass_stored"
+#define NGEN_MASS_LEAKED "ngen::mass_leaked"
+
+#define MASS_BALANCE_VAR_NAME_COUNT 4
+
+#include <bmi.h>
+#include <string.h>
+
+//These are the bare minimum required to interface with ngen
+static const char *mass_balance_var_names[MASS_BALANCE_VAR_NAME_COUNT] = { NGEN_MASS_IN, NGEN_MASS_OUT, NGEN_MASS_STORED, NGEN_MASS_LEAKED };
+static const char *mass_balance_var_types[MASS_BALANCE_VAR_NAME_COUNT] = { "double", "double", "double", "double" };
+static const int   mass_balance_var_item_count[MASS_BALANCE_VAR_NAME_COUNT] = { 1, 1, 1, 1};
+static const char *mass_balance_var_units[MASS_BALANCE_VAR_NAME_COUNT] = { "m", "m", "m", "m" };
+//These may be useful in the future, but aren't strictly necessary for the protocol at the moment
+// static const char *mass_balance_var_grids[MASS_BALANCE_VAR_NAME_COUNT] = { 0, 0, 0 };
+// static const char *mass_balance_var_locations[MASS_BALANCE_VAR_NAME_COUNT] = { "node", "node", "node" };
+
+static inline int get_mass_balance_var_type(const char *name, char *type)
+{
+    for (int i = 0; i < MASS_BALANCE_VAR_NAME_COUNT; ++i) {
+        if (strcmp(name, mass_balance_var_names[i]) == 0) {
+            strncpy(type, mass_balance_var_types[i], BMI_MAX_TYPE_NAME);
+            return BMI_SUCCESS;
+        }
+    }
+    return BMI_FAILURE;
+}
+
+static inline int get_mass_balance_item_count(const char *name)
+{
+    for (int i = 0; i < MASS_BALANCE_VAR_NAME_COUNT; ++i) {
+        if (strcmp(name, mass_balance_var_names[i]) == 0) {
+            return mass_balance_var_item_count[i];
+        }
+    }
+    return -1; // Default to -1 if not found
+}
+
+static inline int get_mass_balance_unit(const char *name, char* unit)
+{
+    for (int i = 0; i < MASS_BALANCE_VAR_NAME_COUNT; ++i) {
+        if (strcmp(name, mass_balance_var_names[i]) == 0) {
+            strncpy(unit, mass_balance_var_units[i], BMI_MAX_UNITS_NAME);
+            return BMI_SUCCESS;
+        }
+    }
+    return BMI_FAILURE;
+}

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3254,6 +3254,7 @@ extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
     cfe_ptr->vol_struct.vol_et_from_retention_depth = 0;
     cfe_ptr->vol_struct.vol_et_to_atm    = 0;
     cfe_ptr->vol_struct.cummulative_vol_in = cfe_ptr->vol_struct.volstart;
+    cfe_ptr->vol_struct.volume_in_domain = cfe_ptr->vol_struct.volstart;
 }
 
 /**************************************************************************/

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3253,6 +3253,7 @@ extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
     cfe_ptr->vol_struct.vol_et_from_rain = 0;
     cfe_ptr->vol_struct.vol_et_from_retention_depth = 0;
     cfe_ptr->vol_struct.vol_et_to_atm    = 0;
+    cfe_ptr->vol_struct.cummulative_vol_in = cfe_ptr->vol_struct.volstart;
 }
 
 /**************************************************************************/

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 #include "bmi.h"
 #include "bmi_cfe.h"
+#include "ngen_utilities.h"
 #include <time.h>
 #include <float.h>
 #ifndef WATER_SPECIFIC_WEIGHT
@@ -1746,6 +1747,11 @@ static int Get_var_type (Bmi *self, const char *name, char * type)
         }
     }
 
+    // Finally check to see if in mass balance array
+    if( get_mass_balance_var_type(name, type) == BMI_SUCCESS ) {
+        return BMI_SUCCESS;
+    }
+
     // If we get here, it means the variable name wasn't recognized
     type[0] = '\0';
     return BMI_FAILURE;
@@ -1828,6 +1834,10 @@ static int Get_var_units (Bmi *self, const char *name, char * units)
             return BMI_SUCCESS;
         }
     }
+    // Finally check to see if in mass balance array
+    if( get_mass_balance_unit(name, units) == BMI_SUCCESS ) {
+        return BMI_SUCCESS;
+    }
     // If we get here, it means the variable name wasn't recognized
     units[0] = '\0';
     return BMI_FAILURE;
@@ -1866,6 +1876,9 @@ static int Get_var_nbytes (Bmi *self, const char *name, int * nbytes)
 	  break;
         }
       }
+    }
+    if (item_count < 1) {
+        item_count = get_mass_balance_item_count(name);
     }
     if (item_count < 1)
         item_count = ((cfe_state_struct *) self->data)->num_timesteps;
@@ -2129,6 +2142,31 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     }
     //-------------------------------------------------------------------
 
+    //Mass Balance protocol
+    if (strcmp (name, NGEN_MASS_IN) == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->vol_struct.cummulative_vol_in;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, NGEN_MASS_OUT) == 0) {
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->vol_struct.volout;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, NGEN_MASS_STORED) == 0){
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->vol_struct.volume_in_domain;
+        return BMI_SUCCESS;
+    }
+    if (strcmp (name, NGEN_MASS_LEAKED) == 0){
+        cfe_state_struct *cfe_ptr;
+        cfe_ptr = (cfe_state_struct *) self->data;
+        *dest = (void*)&cfe_ptr->vol_struct.leakage;
+        return BMI_SUCCESS;
+    }
     return BMI_FAILURE;
 }
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -1557,7 +1557,6 @@ static int Update (Bmi *self)
     //Adjust the rainfall input by a potential fraction of the time step
     cfe_ptr->timestep_rainfall_input_m *= cfe_ptr->time_step_fraction;
     //Accumulate volume for mass balance
-    cfe_ptr->vol_struct.volin += cfe_ptr->timestep_rainfall_input_m;
 
     run_cfe(cfe_ptr);
 

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3256,6 +3256,7 @@ extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
     cfe_ptr->vol_struct.vol_et_to_atm    = 0;
     cfe_ptr->vol_struct.cummulative_vol_in = cfe_ptr->vol_struct.volstart;
     cfe_ptr->vol_struct.volume_in_domain = cfe_ptr->vol_struct.volstart;
+    cfe_ptr->vol_struct.leakage = 0.0;
 }
 
 /**************************************************************************/

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -3232,6 +3232,7 @@ extern void init_soil_reservoir(cfe_state_struct* cfe_ptr)
 }*/
 
 extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
+    cfe_ptr->vol_struct.vol_runon_infilt = 0.0;
     cfe_ptr->vol_struct.volstart         = 0.0;
     cfe_ptr->vol_struct.volin            = 0;
     cfe_ptr->vol_struct.vol_runoff       = 0;

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -2146,7 +2146,7 @@ static int Get_value_ptr (Bmi *self, const char *name, void **dest)
     if (strcmp (name, NGEN_MASS_IN) == 0) {
         cfe_state_struct *cfe_ptr;
         cfe_ptr = (cfe_state_struct *) self->data;
-        *dest = (void*)&cfe_ptr->vol_struct.cummulative_vol_in;
+        *dest = (void*)&cfe_ptr->vol_struct.cumulative_vol;
         return BMI_SUCCESS;
     }
     if (strcmp (name, NGEN_MASS_OUT) == 0) {
@@ -3292,7 +3292,7 @@ extern void initialize_volume_trackers(cfe_state_struct* cfe_ptr) {
     cfe_ptr->vol_struct.vol_et_from_rain = 0;
     cfe_ptr->vol_struct.vol_et_from_retention_depth = 0;
     cfe_ptr->vol_struct.vol_et_to_atm    = 0;
-    cfe_ptr->vol_struct.cummulative_vol_in = cfe_ptr->vol_struct.volstart;
+    cfe_ptr->vol_struct.cumulative_vol = cfe_ptr->vol_struct.volstart;
     cfe_ptr->vol_struct.volume_in_domain = cfe_ptr->vol_struct.volstart;
     cfe_ptr->vol_struct.leakage = 0.0;
 }

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -284,6 +284,26 @@ extern void cfe(
   massbal_struct->vol_in_nash   += flux_lat_m;
   massbal_struct->vol_out_nash  += nash_lateral_runoff_m;
 
+  // Track the total volume held in the domain at the end of the time step
+  int i = 0;
+  //Reservoir storages
+  massbal_struct->volume_in_domain = soil_reservoir_struct->storage_m+gw_reservoir_struct->storage_m;
+  //Surface storage
+  if (surface_runoff_scheme == GIUH) {
+      for(i=0;i<num_giuh_ordinates;i++){
+	      massbal_struct->volume_in_domain += runoff_queue_m_per_timestep_arr[i];
+    }
+  }
+  if (surface_runoff_scheme == NASH_CASCADE){
+    for(i=0;i<nash_surface_params->N_nash; i++){
+      massbal_struct->volume_in_domain += nash_surface_params->nash_storage[i];
+    }
+  }
+  //Subsurface storage
+  for(i=0;i<N_nash_subsurface; i++){
+    massbal_struct->volume_in_domain += nash_storage_arr[i];
+  }
+                    
 #ifdef DEBUG
         fprintf(out_debug_fptr,"%d %lf %lf  %lf\n",tstep,flux_lat_m,nash_lateral_runoff_m,flux_from_deep_gw_to_chan_m);
 #endif

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -69,6 +69,8 @@ extern void cfe(
   // partition rainfall using Schaake function
   //##################################################
   massbal_struct->volin += timestep_rainfall_input_m;
+  massbal_struct->cummulative_vol_in += timestep_rainfall_input_m;
+
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
 

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -68,7 +68,7 @@ extern void cfe(
   //##################################################
   // partition rainfall using Schaake function
   //##################################################
-
+  massbal_struct->volin += timestep_rainfall_input_m;
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
 

--- a/src/cfe.c
+++ b/src/cfe.c
@@ -69,7 +69,7 @@ extern void cfe(
   // partition rainfall using Schaake function
   //##################################################
   massbal_struct->volin += timestep_rainfall_input_m;
-  massbal_struct->cummulative_vol_in += timestep_rainfall_input_m;
+  massbal_struct->cumulative_vol += timestep_rainfall_input_m;
 
   evap_struct->potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;
   evap_struct->reduced_potential_et_m_per_timestep = evap_struct->potential_et_m_per_s * time_step_size;


### PR DESCRIPTION
Implement a basic mass balance BMI protocol which exposes cumulative mass balance terms via the BMI for consumption by some caller.

## Additions

- A set of utility functions for implementing the ngen bmi protocol
- A new mass balance variable for potential (future) leakage terms, needed to implement the required ngen protocol

## Removals

-

## Changes

- Adjustments to CFE's run semantics to ensure storage in the domain is accumulated properly each time step
- Properly initialize various mass balance variables

## Testing

1. Local unit tests pass
2. Checked with an initial prototype version of the model engine protocol

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support
- [x] Linux
- [x] MacOS
