### PR TITLE
Control verbosity of debug output via build config

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -62,6 +62,7 @@ jobs:
         id: submod_build_6
         uses: ./.github/actions/ngen-submod-build
         with:
+          cmake-flags: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           mod-dir: "extern/sloth/"
           targets: "slothmodel"
 

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ bower_components/
 .grunt/
 src/vendor/
 dist/
+
+# IDE-specific Files #
+######################
+.idea

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,25 @@ option(AETROOTZONE "AETROOTZONE" OFF)
 option(NGEN "NGEN" OFF)
 option(UNITTEST "UNITTEST" OFF)
 
+# A numeric verbosity level can be set for debug output printed/logged during execution
+# Use 1 by default when build type is "Debug"
+if (NOT DEFINED DEBUG_VERBOSITY AND "${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    set(DEBUG_VERBOSITY 1)
+# Use 0 by default for any build types other than "Debug"
+elseif (NOT DEFINED DEBUG_VERBOSITY)
+    set(DEBUG_VERBOSITY 0)
+# Catch any "ON" or equivalent, excluding all integers other than "1" (which we want to handle separately)
+elseif (${DEBUG_VERBOSITY} AND NOT ${DEBUG_VERBOSITY} GREATER "1" AND NOT ${DEBUG_VERBOSITY} LESS_EQUAL "0")
+    set(DEBUG_VERBOSITY 1)
+# Should catch any other values except an integer greater than 1 (which we want to use directly)
+elseif (NOT ${DEBUG_VERBOSITY} GREATER "1")
+    set(DEBUG_VERBOSITY 0)
+endif ()
+# While not an explicit condition, DEBUG_VERBOSITY is left alone if set to some integer greater than 1
+
+# TODO: this should ideally be applied to a specific target, but how targets are defined and set up probably needs to be adjusted first
+add_compile_definitions(CFE_DEBUG=${DEBUG_VERBOSITY})
+
 if( (NOT BASE) AND (NOT FORCING) AND (NOT FORCINGPET) AND (NOT AETROOTZONE) AND (NOT NGEN) AND (NOT UNITTEST) )
   message("${Red}Options: BASE, FORCING, FORCINGPET, AETROOTZONE, NGEN, UNITTEST" ${ColourReset})
   message(FATAL_ERROR "Invalid option is provided, CMake will exit." )

--- a/src/bmi_cfe.c
+++ b/src/bmi_cfe.c
@@ -17,8 +17,6 @@
   infiltration by Ahmad Jan Khattak, May 2024.
 *******************************************************************************************************/
 
-#define CFE_DEBUG 0
-
 #define INPUT_VAR_NAME_COUNT 5
 #define OUTPUT_VAR_NAME_COUNT 15
 


### PR DESCRIPTION
Control verbosity of debug output using CMake variable DEBUG_VERBOSITY, rather than hard coding.

## Removals

- Hard-coded setting of `CFE_DEBUG`

## Changes

- CMake build adjusted to accept a `DEBUG_VERBOSITY` variable and use that to set the `CFE_DEBUG` macro via compile definition.

## Testing

1. Tested numerous scenarios to ensure build type or explicit `DEBUG_VERBOSITY` setting results in the desired effect.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
